### PR TITLE
Simplify status rotation

### DIFF
--- a/modules/status.js
+++ b/modules/status.js
@@ -1,17 +1,6 @@
 module.exports = function rotateStatus(client) {
   const statuses = [
     { type: 'WATCHING', text: 'station logs uplink' },
-    { type: 'WATCHING', text: 'cargo logs shift ' },
-    { type: 'WATCHING', text: 'tribunal feed' },
-    { type: 'WATCHING', text: 'reactor output levels' },
-    { type: 'WATCHING', text: 'auto-calibration subroutines' },
-    { type: 'WATCHING', text: '#news-feed telemetry' },
-    { type: 'WATCHING', text: 'command stream authentications' },
-    { type: 'WATCHING', text: 'SubdeckGossip.live' },
-    { type: 'WATCHING', text: 'Dock 3 photo uploads' },
-    { type: 'WATCHING', text: 'profile sync signals' },
-    { type: 'WATCHING', text: 'broadcast loop glitch' },
-    { type: 'WATCHING', text: 'ethics committee dissolve quietly' },
   ];
 
   let i = 0;


### PR DESCRIPTION
## Summary
- keep only one status in `modules/status.js`

## Testing
- `node --check modules/status.js`

------
https://chatgpt.com/codex/tasks/task_e_688931a4f9f8832e93e2c99a33608fe1