### PR TITLE
Enhance tweet command

### DIFF
--- a/commands/tweet.js
+++ b/commands/tweet.js
@@ -7,20 +7,66 @@ module.exports = {
     .setDescription('Post an in-character social feed message')
     .addStringOption(option =>
       option.setName('text')
-        .setDescription('Your message (in-character)')
+        .setDescription('Your message (in-character, up to 400 words)')
         .setRequired(true)
+    )
+    .addStringOption(option =>
+      option.setName('hashtags')
+        .setDescription('Space separated hashtags (max 4)')
+        .setRequired(false)
+    )
+    .addStringOption(option =>
+      option.setName('image')
+        .setDescription('Imgur image link')
+        .setRequired(false)
     ),
 
   execute: withInteractionHandler(async (interaction) => {
     const text = interaction.options.getString('text');
+    const hashtagsInput = interaction.options.getString('hashtags');
+    const imageUrl = interaction.options.getString('image');
+
+    const words = text.trim().split(/\s+/).filter(Boolean);
+    if (words.length > 400) {
+      await interaction.editReply({
+        content: '❌ Message must be 400 words or fewer.',
+        ephemeral: true,
+      });
+      return;
+    }
+
+    const hashtags = hashtagsInput
+      ? hashtagsInput
+          .trim()
+          .split(/\s+/)
+          .filter(Boolean)
+          .slice(0, 4)
+          .map((tag) => (tag.startsWith('#') ? tag : `#${tag}`))
+      : [];
+
+    if (imageUrl && !/imgur\.com/.test(imageUrl)) {
+      await interaction.editReply({
+        content: '❌ Image must be hosted on Imgur.',
+        ephemeral: true,
+      });
+      return;
+    }
+
     const username = interaction.user.username;
     const avatar = interaction.user.displayAvatarURL();
 
+    const descriptionParts = [`"${text}"`];
+    if (hashtags.length) descriptionParts.push(hashtags.join(' '));
+
     const embed = new EmbedBuilder()
       .setAuthor({ name: `@${username}`, iconURL: avatar })
-      .setDescription(`"${text}"`)
+      .setDescription(descriptionParts.join('\n\n'))
       .setFooter({ text: ` NEXI Social Feed` })
       .setColor(0x2c3e50);
+
+    if (imageUrl) {
+      embed.setImage(imageUrl);
+    }
 
     const channel = interaction.guild.channels.cache.find(
       c => c.name === process.env.NEWS_CHANNEL_NAME && c.isTextBased()


### PR DESCRIPTION
## Summary
- allow optional hashtags and image for `/tweet`
- limit tweet text to 400 words

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688935438434832e94992530a881242d