### PR TITLE
Fix presence not updating on startup

### DIFF
--- a/modules/status.js
+++ b/modules/status.js
@@ -1,20 +1,30 @@
+const { ActivityType } = require('discord.js');
+
 module.exports = function rotateStatus(client) {
   const statuses = [
-    { type: 'WATCHING', text: 'station logs uplink' },
+    { type: ActivityType.Watching, text: 'station logs uplink' },
   ];
 
   let i = 0;
-setInterval(() => {
-  const s = statuses[i % statuses.length];
-client.user.setPresence({
-  activities: [{
-    name: `${s.text} ​`, // <-- includes an invisible space (U+200B)
-    type: s.type
-  }],
-  status: 'online'
-});
-  console.log(`🛰️ Status set to: ${s.type} ${s.text}`);
-  i++;
-}, 10 * 60 * 1000);
-// every 10 minutes
+
+  const updateStatus = () => {
+    const s = statuses[i % statuses.length];
+    client.user.setPresence({
+      activities: [
+        {
+          name: `${s.text} \u200B`, // includes an invisible space (U+200B)
+          type: s.type,
+        },
+      ],
+      status: 'online',
+    });
+    console.log(`🛰️ Status set to: ${s.type} ${s.text}`);
+    i++;
+  };
+
+  // Set immediately on startup
+  updateStatus();
+
+  // Rotate every 10 minutes
+  setInterval(updateStatus, 10 * 60 * 1000);
 };


### PR DESCRIPTION
## Summary
- update status module to set initial presence and use `ActivityType`

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688937b7dcb8832ea71d0036c138fc1f