### PR TITLE
Enable member intent for tweet mentions

### DIFF
--- a/commands/tweet.js
+++ b/commands/tweet.js
@@ -22,11 +22,11 @@ module.exports = {
     ),
 
   execute: withInteractionHandler(async (interaction) => {
-    const text = interaction.options.getString('text');
+    const rawText = interaction.options.getString('text');
     const hashtagsInput = interaction.options.getString('hashtags');
     const imageUrl = interaction.options.getString('image');
 
-    const words = text.trim().split(/\s+/).filter(Boolean);
+    const words = rawText.trim().split(/\s+/).filter(Boolean);
     if (words.length > 400) {
       await interaction.editReply({
         content: '❌ Message must be 400 words or fewer.',
@@ -51,6 +51,15 @@ module.exports = {
       });
       return;
     }
+
+    const members = await interaction.guild.members.fetch();
+    const text = rawText.replace(/@([^\s]+)/g, (match, name) => {
+      const member = members.find(m =>
+        m.user.username.toLowerCase() === name.toLowerCase() ||
+        m.displayName.toLowerCase() === name.toLowerCase()
+      );
+      return member ? `<@${member.id}>` : match;
+    });
 
     const username = interaction.user.username;
     const avatar = interaction.user.displayAvatarURL();

--- a/index.js
+++ b/index.js
@@ -12,7 +12,8 @@ const client = new Client({
     intents: [
         GatewayIntentBits.Guilds,
         GatewayIntentBits.GuildMessages,
-        GatewayIntentBits.GuildPresences
+        GatewayIntentBits.GuildPresences,
+        GatewayIntentBits.GuildMembers
     ]
 });
 


### PR DESCRIPTION
## Summary
- add `GatewayIntentBits.GuildMembers` so `/tweet` can look up guild members

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68894c349720832e886eaaab14db6a10