### PR TITLE
Simplify Calisa VII flow

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const { Client, GatewayIntentBits, Collection } = require('discord.js');
 const { startNewsCycle } = require('./modules/news');
 const rotateStatus = require('./modules/status');
 const { startAdLoop } = require('./modules/ads');
-const { sendCalisaWelcome, showCalisaMenu, handleCalisaOption } = require('./modules/calisa');
+const { showCalisaMenu, handleCalisaOption } = require('./modules/calisa');
 
 const client = new Client({
     intents: [
@@ -71,10 +71,9 @@ client.on('interactionCreate', async interaction => {
             const member = interaction.member;
             const guild = interaction.guild;
             const calisaRole = guild.roles.cache.find(r => r.name === 'CALISA VII');
-            const calisaChannel = guild.channels.cache.find(c => c.name === 'calisa-vii' && c.isTextBased());
 
-            if (!calisaRole || !calisaChannel) {
-                await interaction.reply({ content: '❌ Calisa role or channel not found.', ephemeral: true });
+            if (!calisaRole) {
+                await interaction.reply({ content: '❌ Calisa role not found.', ephemeral: true });
                 return;
             }
 
@@ -84,21 +83,13 @@ client.on('interactionCreate', async interaction => {
             }
 
             await member.roles.add(calisaRole);
-            await calisaChannel.send({ content: `🌺 <@${member.id}> has arrived on **Calisa VII**.` });
-            await sendCalisaWelcome(calisaChannel, member.id);
 
-            await interaction.reply({
-                content: '🎫 Welcome aboard. You’re being transported to Calisa VII...',
-                ephemeral: true,
-            });
-            return;
-        }
+            await interaction.channel.send({ content: `🌺 <@${member.id}> has departed for **Calisa VII**...` });
 
-        // 🧭 START VACATION BUTTON
-        if (interaction.customId === 'start_vacation') {
             await showCalisaMenu(interaction);
             return;
         }
+
 
         // 🧭 CALISA OPTION + SUBPATH HANDLER
         if (scope === 'calisa' && (category.startsWith('option') || category.startsWith('mtn'))) {

--- a/modules/calisa.js
+++ b/modules/calisa.js
@@ -6,26 +6,6 @@ const {
   StringSelectMenuBuilder,
 } = require('discord.js');
 
-async function sendCalisaWelcome(channel, userId) {
-  const embed = new EmbedBuilder()
-    .setTitle(' WELCOME TO CALISA VII ')
-    .setDescription(
-      `*Breathe in the nectar-thick air. Let the suns kiss your skin. Forget the war, the politics, the void. Just for a little while.*\n\n` +
-      `After months in orbital rust, Calisa VII glows like a hallucination: twin suns, bioluminescent reefs, whispering forests, and gravity set just low enough to make your body feel born again. The shuttle drops you near Coralport — a coastal node strung between cliffs and lagoons. Your bags are already ashore. Your neural inbox is blissfully silent.\n\n` +
-      `**<@${userId}> — what will you do first?**`
-    )
-    .setImage('https://i.imgur.com/cMnHiUs.png')
-    .setColor(0xff77aa);
-
-  const row = new ActionRowBuilder().addComponents(
-    new ButtonBuilder()
-      .setCustomId('start_vacation')
-      .setLabel(' Start Vacation')
-      .setStyle(ButtonStyle.Secondary)
-  );
-
-  await channel.send({ embeds: [embed], components: [row] });
-}
 
 async function showCalisaMenu(interaction) {
   const embed = new EmbedBuilder()
@@ -140,7 +120,11 @@ async function handleCalisaOption(interaction) {
       break;
 
     case 'calisa_mtn_forest':
-      text = `The **forest whispers**. Light bends wrong between twisted trees. A tall, elfin figure hums in chords your ears weren't built to parse. You follow — not out of fear, but recognition.`;
+      text =
+        'The light bends strangely between the branches. A figure finds you: elfin, tall, humming in chords your ears weren\'t built to parse. It watches you with mirrored eyes.\n' +
+        'After days you earn its trust. It leans close and whispers:\n' +
+        '"None of this is real. Not Calisa. Not the suns. Not even the war. We are fragments in a Discord server… echoing choices someone else thinks they made."\n' +
+        'You laugh. Or cry. Or both.';
       img = 'https://i.imgur.com/D7kNv3a.jpeg';
       break;
 
@@ -161,6 +145,21 @@ async function handleCalisaOption(interaction) {
 
   await interaction.reply({ embeds: [embed], ephemeral: true });
 
+  if (choice === 'calisa_mtn_forest') {
+    const newsChannel = interaction.guild.channels.cache.find(
+      c => c.name === process.env.NEWS_CHANNEL_NAME && c.isTextBased()
+    );
+    if (newsChannel) {
+      await newsChannel.send(
+        '**CALISA VII: GUEST CLAIMS REALITY IS A DISCORD SERVER**\n' +
+          'Tourist returns from forest hike raving about an "elf-coded entity" who revealed:\n' +
+          '"None of this is real. We\'re fragments in a Discord server."\n' +
+          'Local guides blame hallucinogenic pollen. Vacation officials offer memory wipes "for those troubled by metaphysical recursion."\n' +
+          '#ForestGlitch #DiscordMythos #SimulationLeak'
+      );
+    }
+  }
+
   // ⛔ Disable buttons on original message after first choice
   if (interaction.message?.components?.length) {
     const disabledRow = new ActionRowBuilder().addComponents(
@@ -178,7 +177,6 @@ async function handleCalisaOption(interaction) {
 }
 
 module.exports = {
-  sendCalisaWelcome,
   showCalisaMenu,
   handleCalisaOption,
 };


### PR DESCRIPTION
## Summary
- remove old Calisa welcome step and `start_vacation` button
- show destination menu immediately when ticket is purchased
- announce departures in the current channel
- add mysterious forest ending with news-feed post

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a00ad9bec832eb66b48c6edd1376a