### PR TITLE
Fix mountain dropdown staying active

### DIFF
--- a/modules/calisa.js
+++ b/modules/calisa.js
@@ -112,6 +112,21 @@ async function handleCalisaOption(interaction) {
         components: [new ActionRowBuilder().addComponents(mountainSelect)],
         ephemeral: true,
       });
+      if (interaction.message?.components?.length) {
+        const row = interaction.message.components[0];
+        const disabled = row.components.map(comp => {
+          const json = comp.toJSON();
+          return json.type === 3
+            ? StringSelectMenuBuilder.from(comp).setDisabled(true)
+            : ButtonBuilder.from(comp).setDisabled(true);
+        });
+        const disabledRow = new ActionRowBuilder().addComponents(disabled);
+        try {
+          await interaction.message.edit({ components: [disabledRow] });
+        } catch (err) {
+          console.warn('⚠️ Could not disable components:', err.message);
+        }
+      }
       return;
 
     case 'calisa_mtn_hut':


### PR DESCRIPTION
## Summary
- disable components immediately after selecting the mountain option so the dropdown becomes inactive
- keep existing menu disabling logic for the other choices

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a12f268f0832eaa42a5a727b792fc