### PR TITLE
Add end option to mountain dropdown

### DIFF
--- a/modules/calisa.js
+++ b/modules/calisa.js
@@ -100,6 +100,11 @@ async function handleCalisaOption(interaction) {
             value: 'calisa_mtn_forest',
             emoji: '🌲',
           },
+          {
+            label: 'End Vacation',
+            value: 'calisa_option_end',
+            emoji: '🔚',
+          },
         ]);
 
       const mountainEmbed = new EmbedBuilder()


### PR DESCRIPTION
## Summary
- extend mountain options dropdown with an "End Vacation" option

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a12f64768832e8ebed155c303b5d4