### PR TITLE
Fix Calisa menu not disabling after selection

### DIFF
--- a/__tests__/calisa.test.js
+++ b/__tests__/calisa.test.js
@@ -11,28 +11,28 @@ describe('calisa module', () => {
     const interaction = {
       isStringSelectMenu: () => true,
       values: ['calisa_option_hotel'],
-      reply: jest.fn().mockResolvedValue(),
+      update: jest.fn().mockResolvedValue(),
       guild: { channels: { cache: { find: jest.fn() } } },
-      message: { components: [row], edit: jest.fn().mockResolvedValue() },
+      message: { components: [row] },
     };
 
     await handleCalisaOption(interaction);
 
-    expect(interaction.message.edit).toHaveBeenCalled();
+    expect(interaction.update).toHaveBeenCalled();
   });
 
   test('mountain option shows a select menu', async () => {
     const interaction = {
       isStringSelectMenu: () => true,
       values: ['calisa_option_mountain'],
-      reply: jest.fn().mockResolvedValue(),
+      update: jest.fn().mockResolvedValue(),
       guild: { channels: { cache: { find: jest.fn() } } },
-      message: { components: [], edit: jest.fn().mockResolvedValue() },
+      message: { components: [] },
     };
 
     await handleCalisaOption(interaction);
 
-    const components = interaction.reply.mock.calls[0][0].components;
+    const components = interaction.update.mock.calls[0][0].components;
     expect(components).toHaveLength(1);
     const menu = components[0].components[0];
     expect(menu).toBeInstanceOf(StringSelectMenuBuilder);

--- a/modules/calisa.js
+++ b/modules/calisa.js
@@ -66,6 +66,7 @@ async function handleCalisaOption(interaction) {
   let text = '';
   let img = null;
 
+  let components = [];
   switch (choice) {
     case 'calisa_option_hotel':
       text = `You check into the **Skyglass Hotel**, a towering shell of glass and biovine scaffolds overlooking the opal sea. Your room hums with soft ambient synth, a zero-g bath pod awaits, and scent-curtains recall your best memories.`;
@@ -107,32 +108,8 @@ async function handleCalisaOption(interaction) {
           },
         ]);
 
-      const mountainEmbed = new EmbedBuilder()
-        .setDescription(text)
-        .setImage(img)
-        .setColor(0xff77aa);
-
-      await interaction.reply({
-        embeds: [mountainEmbed],
-        components: [new ActionRowBuilder().addComponents(mountainSelect)],
-        ephemeral: true,
-      });
-      if (interaction.message?.components?.length) {
-        const row = interaction.message.components[0];
-        const disabled = row.components.map(comp => {
-          const json = comp.toJSON();
-          return json.type === 3
-            ? StringSelectMenuBuilder.from(comp).setDisabled(true)
-            : ButtonBuilder.from(comp).setDisabled(true);
-        });
-        const disabledRow = new ActionRowBuilder().addComponents(disabled);
-        try {
-          await interaction.message.edit({ components: [disabledRow] });
-        } catch (err) {
-          console.warn('⚠️ Could not disable components:', err.message);
-        }
-      }
-      return;
+      components = [new ActionRowBuilder().addComponents(mountainSelect)];
+      break;
 
     case 'calisa_mtn_hut':
       text = `You settle into a **mountain hut**, heated with volcanic vents and lit by ancient fiber-lanterns. A local elder tells stories of when the stars were closer. Outside, mist curls like memory.`;
@@ -159,7 +136,7 @@ async function handleCalisaOption(interaction) {
       break;
 
     default:
-      await interaction.reply({ content: '⚠️ Unknown option.', ephemeral: true });
+      await interaction.update({ content: '⚠️ Unknown option.', components: [] });
       return;
   }
 
@@ -168,7 +145,7 @@ async function handleCalisaOption(interaction) {
     .setImage(img)
     .setColor(0xff77aa);
 
-  await interaction.reply({ embeds: [embed], ephemeral: true });
+  await interaction.update({ embeds: [embed], components });
 
   if (choice === 'calisa_mtn_forest') {
     const newsChannel = interaction.guild.channels.cache.find(
@@ -185,22 +162,6 @@ async function handleCalisaOption(interaction) {
     }
   }
 
-  // ⛔ Disable menu/buttons on original message after first choice
-  if (interaction.message?.components?.length) {
-    const row = interaction.message.components[0];
-    const disabled = row.components.map(comp => {
-      const json = comp.toJSON();
-      return json.type === 3
-        ? StringSelectMenuBuilder.from(comp).setDisabled(true)
-        : ButtonBuilder.from(comp).setDisabled(true);
-    });
-    const disabledRow = new ActionRowBuilder().addComponents(disabled);
-    try {
-      await interaction.message.edit({ components: [disabledRow] });
-    } catch (err) {
-      console.warn('⚠️ Could not disable components:', err.message);
-    }
-  }
 }
 
 module.exports = {


### PR DESCRIPTION
## Summary
- disable dropdowns by updating the interaction message instead of replying
- update tests accordingly

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688a170d4174832e8e2e9edae7f6753c