### PR TITLE
Replace Calisa emojis with server emoji

### DIFF
--- a/modules/calisa.js
+++ b/modules/calisa.js
@@ -24,17 +24,17 @@ async function showCalisaMenu(interaction) {
       {
         label: 'Skyglass Hotel',
         value: 'calisa_option_hotel',
-        emoji: '🌴',
+        emoji: { id: '1399477691278692352' },
       },
       {
         label: 'Beach Hut',
         value: 'calisa_option_beach',
-        emoji: '🛖',
+        emoji: { id: '1399477691278692352' },
       },
       {
         label: 'Calisan Mountains',
         value: 'calisa_option_mountain',
-        emoji: '🏔',
+        emoji: { id: '1399477691278692352' },
       },
     ]);
 
@@ -89,22 +89,22 @@ async function handleCalisaOption(interaction) {
           {
             label: 'Chill in Mountain Hut',
             value: 'calisa_mtn_hut',
-            emoji: '🛖',
+            emoji: { id: '1399477691278692352' },
           },
           {
             label: 'Climb to the Mountain Top',
             value: 'calisa_mtn_climb',
-            emoji: '🧗',
+            emoji: { id: '1399477691278692352' },
           },
           {
             label: 'Explore the Forest',
             value: 'calisa_mtn_forest',
-            emoji: '🌲',
+            emoji: { id: '1399477691278692352' },
           },
           {
             label: 'End Vacation',
             value: 'calisa_option_end',
-            emoji: '🔚',
+            emoji: { id: '1399477691278692352' },
           },
         ]);
 


### PR DESCRIPTION
## Summary
- customize Calisa adventure menus with a single server emoji

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a67b6a1b0832e97a7ccf258a86a7e