### PR TITLE
Implement /review slash command

### DIFF
--- a/__tests__/review.test.js
+++ b/__tests__/review.test.js
@@ -1,0 +1,30 @@
+const { handleReviewModal } = require('../modules/review');
+const { EmbedBuilder } = require('discord.js');
+
+describe('review module', () => {
+  test('posts embed and replies', async () => {
+    process.env.NEWS_CHANNEL_NAME = 'news-feed';
+    const send = jest.fn().mockResolvedValue();
+    const interaction = {
+      guild: { channels: { cache: { find: jest.fn(() => ({ send })) } } },
+      fields: { getTextInputValue: jest.fn(id => {
+          const data = {
+            review_target: 'Calisa VII',
+            review_summary: 'Nice place',
+            review_detail: 'Long review',
+            review_ratings: '{"hospitality":1,"price":2,"crowd":3,"cleanliness":4,"transport":5}'
+          };
+          return data[id];
+      }) },
+      user: { username: 'tester', displayAvatarURL: () => 'https://example.com/avatar.png' },
+      reply: jest.fn().mockResolvedValue(),
+    };
+
+    await handleReviewModal(interaction);
+
+    expect(send).toHaveBeenCalled();
+    const embed = send.mock.calls[0][0].embeds[0];
+    expect(embed).toBeInstanceOf(EmbedBuilder);
+    expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({ ephemeral: true }));
+  });
+});

--- a/commands/review.js
+++ b/commands/review.js
@@ -1,0 +1,55 @@
+const { SlashCommandBuilder, ModalBuilder, TextInputBuilder, TextInputStyle, ActionRowBuilder } = require('discord.js');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('review')
+    .setDescription('Submit a structured player review'),
+
+  async execute(interaction) {
+    if (interaction.channel?.name !== process.env.NEWS_CHANNEL_NAME) {
+      await interaction.reply({
+        content: '❌ This command can only be used in the #news-feed channel.',
+        ephemeral: true,
+      });
+      return;
+    }
+
+    const modal = new ModalBuilder()
+      .setCustomId('review_modal')
+      .setTitle('Submit Review');
+
+    const targetInput = new TextInputBuilder()
+      .setCustomId('review_target')
+      .setLabel('Target Name')
+      .setStyle(TextInputStyle.Short)
+      .setRequired(true);
+
+    const summaryInput = new TextInputBuilder()
+      .setCustomId('review_summary')
+      .setLabel('Summary Line')
+      .setStyle(TextInputStyle.Short)
+      .setRequired(true);
+
+    const detailInput = new TextInputBuilder()
+      .setCustomId('review_detail')
+      .setLabel('Detail Review (optional)')
+      .setStyle(TextInputStyle.Paragraph)
+      .setRequired(false);
+
+    const ratingsInput = new TextInputBuilder()
+      .setCustomId('review_ratings')
+      .setLabel('Ratings JSON')
+      .setStyle(TextInputStyle.Short)
+      .setRequired(true)
+      .setPlaceholder('{ "hospitality":1, "price":2 }');
+
+    modal.addComponents(
+      new ActionRowBuilder().addComponents(targetInput),
+      new ActionRowBuilder().addComponents(summaryInput),
+      new ActionRowBuilder().addComponents(detailInput),
+      new ActionRowBuilder().addComponents(ratingsInput)
+    );
+
+    await interaction.showModal(modal);
+  },
+};

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ const { startNewsCycle } = require('./modules/news');
 const rotateStatus = require('./modules/status');
 const { startAdLoop } = require('./modules/ads');
 const { showCalisaMenu, handleCalisaOption } = require('./modules/calisa');
+const { handleReviewModal } = require('./modules/review');
 
 const client = new Client({
     intents: [
@@ -105,6 +106,12 @@ client.on('interactionCreate', async interaction => {
          interaction.customId === 'calisa_select_mountain')
     ) {
         await handleCalisaOption(interaction);
+        return;
+    }
+
+    // REVIEW MODAL SUBMISSION
+    if (interaction.isModalSubmit() && interaction.customId === 'review_modal') {
+        await handleReviewModal(interaction);
         return;
     }
 

--- a/modules/review.js
+++ b/modules/review.js
@@ -1,0 +1,46 @@
+const { EmbedBuilder } = require('discord.js');
+
+async function handleReviewModal(interaction) {
+  const target = interaction.fields.getTextInputValue('review_target');
+  const summary = interaction.fields.getTextInputValue('review_summary');
+  const detail = interaction.fields.getTextInputValue('review_detail');
+  const ratingsRaw = interaction.fields.getTextInputValue('review_ratings');
+
+  let ratings;
+  try {
+    ratings = JSON.parse(ratingsRaw);
+  } catch {
+    await interaction.reply({ content: '❌ Invalid ratings JSON.', ephemeral: true });
+    return;
+  }
+
+  const embed = new EmbedBuilder()
+    .setTitle(`${target} — Player Review`)
+    .setAuthor({ name: interaction.user.username, iconURL: interaction.user.displayAvatarURL() })
+    .setDescription(summary)
+    .setColor(0x2c3e50);
+
+  const keys = ['hospitality', 'price', 'crowd', 'cleanliness', 'transport'];
+  for (const key of keys) {
+    if (ratings[key] !== undefined) {
+      embed.addFields({ name: key.charAt(0).toUpperCase() + key.slice(1), value: String(ratings[key]), inline: true });
+    }
+  }
+
+  if (detail) {
+    embed.addFields({ name: 'Full Review', value: `||${detail}||` });
+  }
+
+  const channel = interaction.guild.channels.cache.find(
+    c => c.name === process.env.NEWS_CHANNEL_NAME && c.isTextBased()
+  );
+  if (!channel) {
+    await interaction.reply({ content: '❌ Could not find the news-feed channel.', ephemeral: true });
+    return;
+  }
+
+  await channel.send({ embeds: [embed] });
+  await interaction.reply({ content: '✅ Review posted!', ephemeral: true });
+}
+
+module.exports = { handleReviewModal };


### PR DESCRIPTION
## Summary
- create `/review` slash command that displays a modal
- process modal input in a new review module
- handle modal submissions in the interaction handler
- test review embed creation

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688b07ce47f4832eb464b2caaa6e6e2a