### PR TITLE
Handle errors when posting review

### DIFF
--- a/__tests__/review.test.js
+++ b/__tests__/review.test.js
@@ -27,4 +27,31 @@ describe('review module', () => {
     expect(embed).toBeInstanceOf(EmbedBuilder);
     expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({ ephemeral: true }));
   });
+
+  test('handles error when sending embed', async () => {
+    process.env.NEWS_CHANNEL_NAME = 'news-feed';
+    const send = jest.fn().mockRejectedValue(new Error('fail'));
+    const interaction = {
+      guild: { channels: { cache: { find: jest.fn(() => ({ send })) } } },
+      fields: {
+        getTextInputValue: jest.fn(id => {
+          const data = {
+            review_target: 'Calisa VII',
+            review_summary: 'Nice place',
+            review_detail: 'Long review',
+            review_ratings: '{"hospitality":1,"price":2,"crowd":3,"cleanliness":4,"transport":5}'
+          };
+          return data[id];
+        })
+      },
+      user: { username: 'tester', displayAvatarURL: () => 'https://example.com/avatar.png' },
+      reply: jest.fn().mockResolvedValue(),
+    };
+    console.error = jest.fn();
+
+    await handleReviewModal(interaction);
+
+    expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({ ephemeral: true }));
+    expect(console.error).toHaveBeenCalled();
+  });
 });

--- a/modules/review.js
+++ b/modules/review.js
@@ -39,7 +39,14 @@ async function handleReviewModal(interaction) {
     return;
   }
 
-  await channel.send({ embeds: [embed] });
+  try {
+    await channel.send({ embeds: [embed] });
+  } catch (err) {
+    console.error('❌ Failed to post review:', err);
+    await interaction.reply({ content: '❌ Failed to post review.', ephemeral: true });
+    return;
+  }
+
   await interaction.reply({ content: '✅ Review posted!', ephemeral: true });
 }
 


### PR DESCRIPTION
## Summary
- catch `channel.send` errors when posting reviews
- reply ephemerally on failure and log
- add a unit test for the failure case

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688b269ca414832ead79dfb03ac2279a