### PR TITLE
Support hashtags and images for /review

### DIFF
--- a/__tests__/review.test.js
+++ b/__tests__/review.test.js
@@ -28,6 +28,37 @@ describe('review module', () => {
     expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({ ephemeral: true }));
   });
 
+  test('handles hashtags and image attachment', async () => {
+    process.env.NEWS_CHANNEL_NAME = 'news-feed';
+    const send = jest.fn().mockResolvedValue();
+    const fetch = jest.fn().mockResolvedValue({
+      attachments: { first: () => ({ url: 'https://example.com/img.png' }) }
+    });
+    const interaction = {
+      customId: 'review_modal|cool|123',
+      guild: { channels: { cache: { find: jest.fn(() => ({ send })) } } },
+      channel: { messages: { fetch } },
+      fields: { getTextInputValue: jest.fn(id => {
+          const data = {
+            review_target: 'Calisa VII',
+            review_summary: 'Nice place',
+            review_detail: '',
+            review_ratings: '{"hospitality":1}'
+          };
+          return data[id];
+      }) },
+      user: { username: 'tester', displayAvatarURL: () => 'https://example.com/avatar.png' },
+      reply: jest.fn().mockResolvedValue(),
+    };
+
+    await handleReviewModal(interaction);
+
+    expect(send).toHaveBeenCalled();
+    const embed = send.mock.calls[0][0].embeds[0];
+    expect(embed.data.description).toMatch(/#cool/);
+    expect(embed.data.image.url).toBe('https://example.com/img.png');
+  });
+
   test('handles error when sending embed', async () => {
     process.env.NEWS_CHANNEL_NAME = 'news-feed';
     const send = jest.fn().mockRejectedValue(new Error('fail'));

--- a/commands/review.js
+++ b/commands/review.js
@@ -3,7 +3,15 @@ const { SlashCommandBuilder, ModalBuilder, TextInputBuilder, TextInputStyle, Act
 module.exports = {
   data: new SlashCommandBuilder()
     .setName('review')
-    .setDescription('Submit a structured player review'),
+    .setDescription('Submit a structured player review')
+    .addStringOption(option =>
+      option.setName('hashtags')
+        .setDescription('Space separated hashtags (max 4)')
+        .setRequired(false))
+    .addStringOption(option =>
+      option.setName('image')
+        .setDescription('Message ID of an uploaded image')
+        .setRequired(false)),
 
   async execute(interaction) {
     if (interaction.channel?.name !== process.env.NEWS_CHANNEL_NAME) {
@@ -14,8 +22,14 @@ module.exports = {
       return;
     }
 
+    const hashtagsInput = interaction.options.getString('hashtags');
+    const imageId = interaction.options.getString('image');
+
+    const encodedTags = encodeURIComponent(hashtagsInput || '');
+    const encodedImageId = encodeURIComponent(imageId || '');
+
     const modal = new ModalBuilder()
-      .setCustomId('review_modal')
+      .setCustomId(`review_modal|${encodedTags}|${encodedImageId}`)
       .setTitle('Submit Review');
 
     const targetInput = new TextInputBuilder()


### PR DESCRIPTION
## Summary
- allow hashtags and message IDs as optional parameters for `/review`
- encode options into review modal customId
- parse hashtags and load attached image when posting review
- add tests for hashtags and attachment handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688b3ee503bc832e8fbe8799d292f767