### PR TITLE
Simplify review modal fields

### DIFF
--- a/__tests__/review.test.js
+++ b/__tests__/review.test.js
@@ -11,8 +11,9 @@ describe('review module', () => {
           const data = {
             review_target: 'Calisa VII',
             review_summary: 'Nice place',
-            review_detail: 'Long review',
-            review_ratings: '{"hospitality":1,"price":2,"crowd":3,"cleanliness":4,"transport":5}'
+            review_ratings: '{"hospitality":1,"price":2,"crowd":3,"cleanliness":4,"transport":5}',
+            review_hashtags: '',
+            review_image: ''
           };
           return data[id];
       }) },
@@ -35,15 +36,15 @@ describe('review module', () => {
       attachments: { first: () => ({ url: 'https://example.com/img.png' }) }
     });
     const interaction = {
-      customId: 'review_modal|cool|123',
       guild: { channels: { cache: { find: jest.fn(() => ({ send })) } } },
       channel: { messages: { fetch } },
       fields: { getTextInputValue: jest.fn(id => {
           const data = {
             review_target: 'Calisa VII',
             review_summary: 'Nice place',
-            review_detail: '',
-            review_ratings: '{"hospitality":1}'
+            review_ratings: '{"hospitality":1}',
+            review_hashtags: 'cool',
+            review_image: '123'
           };
           return data[id];
       }) },
@@ -69,8 +70,9 @@ describe('review module', () => {
           const data = {
             review_target: 'Calisa VII',
             review_summary: 'Nice place',
-            review_detail: 'Long review',
-            review_ratings: '{"hospitality":1,"price":2,"crowd":3,"cleanliness":4,"transport":5}'
+            review_ratings: '{"hospitality":1,"price":2,"crowd":3,"cleanliness":4,"transport":5}',
+            review_hashtags: '',
+            review_image: ''
           };
           return data[id];
         })

--- a/commands/review.js
+++ b/commands/review.js
@@ -3,15 +3,7 @@ const { SlashCommandBuilder, ModalBuilder, TextInputBuilder, TextInputStyle, Act
 module.exports = {
   data: new SlashCommandBuilder()
     .setName('review')
-    .setDescription('Submit a structured player review')
-    .addStringOption(option =>
-      option.setName('hashtags')
-        .setDescription('Space separated hashtags (max 4)')
-        .setRequired(false))
-    .addStringOption(option =>
-      option.setName('image')
-        .setDescription('Message ID of an uploaded image')
-        .setRequired(false)),
+    .setDescription('Submit a structured player review'),
 
   async execute(interaction) {
     if (interaction.channel?.name !== process.env.NEWS_CHANNEL_NAME) {
@@ -22,14 +14,8 @@ module.exports = {
       return;
     }
 
-    const hashtagsInput = interaction.options.getString('hashtags');
-    const imageId = interaction.options.getString('image');
-
-    const encodedTags = encodeURIComponent(hashtagsInput || '');
-    const encodedImageId = encodeURIComponent(imageId || '');
-
     const modal = new ModalBuilder()
-      .setCustomId(`review_modal|${encodedTags}|${encodedImageId}`)
+      .setCustomId('review_modal')
       .setTitle('Submit Review');
 
     const targetInput = new TextInputBuilder()
@@ -44,12 +30,6 @@ module.exports = {
       .setStyle(TextInputStyle.Short)
       .setRequired(true);
 
-    const detailInput = new TextInputBuilder()
-      .setCustomId('review_detail')
-      .setLabel('Detail Review (optional)')
-      .setStyle(TextInputStyle.Paragraph)
-      .setRequired(false);
-
     const ratingsInput = new TextInputBuilder()
       .setCustomId('review_ratings')
       .setLabel('Ratings JSON')
@@ -57,11 +37,24 @@ module.exports = {
       .setRequired(true)
       .setPlaceholder('{ "hospitality":1, "price":2 }');
 
+    const hashtagsInput = new TextInputBuilder()
+      .setCustomId('review_hashtags')
+      .setLabel('Hashtags (optional)')
+      .setStyle(TextInputStyle.Short)
+      .setRequired(false);
+
+    const imageInput = new TextInputBuilder()
+      .setCustomId('review_image')
+      .setLabel('Image Message ID (optional)')
+      .setStyle(TextInputStyle.Short)
+      .setRequired(false);
+
     modal.addComponents(
       new ActionRowBuilder().addComponents(targetInput),
       new ActionRowBuilder().addComponents(summaryInput),
-      new ActionRowBuilder().addComponents(detailInput),
-      new ActionRowBuilder().addComponents(ratingsInput)
+      new ActionRowBuilder().addComponents(ratingsInput),
+      new ActionRowBuilder().addComponents(hashtagsInput),
+      new ActionRowBuilder().addComponents(imageInput)
     );
 
     await interaction.showModal(modal);

--- a/modules/review.js
+++ b/modules/review.js
@@ -1,15 +1,11 @@
 const { EmbedBuilder } = require('discord.js');
 
 async function handleReviewModal(interaction) {
-  const [, encodedTags = '', encodedImage = ''] =
-    (interaction.customId || '').split('|');
-
-  const hashtagsInput = decodeURIComponent(encodedTags);
-  const imageMessageId = decodeURIComponent(encodedImage);
+  const hashtagsInput = interaction.fields.getTextInputValue('review_hashtags');
+  const imageMessageId = interaction.fields.getTextInputValue('review_image');
 
   const target = interaction.fields.getTextInputValue('review_target');
   const summary = interaction.fields.getTextInputValue('review_summary');
-  const detail = interaction.fields.getTextInputValue('review_detail');
   const ratingsRaw = interaction.fields.getTextInputValue('review_ratings');
 
   let ratings;
@@ -45,9 +41,6 @@ async function handleReviewModal(interaction) {
     }
   }
 
-  if (detail) {
-    embed.addFields({ name: 'Full Review', value: detail });
-  }
 
   if (imageMessageId) {
     try {


### PR DESCRIPTION
## Summary
- drop `hashtags` and `image` slash options from `/review`
- add optional text inputs to the modal instead
- drop the detail field to stay within Discord's 5 input limit
- adjust review module for the new fields
- update tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688b4412f528832e98ea894fc2456fd4