### PR TITLE
Implement full text for reviews

### DIFF
--- a/__tests__/review.test.js
+++ b/__tests__/review.test.js
@@ -11,7 +11,7 @@ describe('review module', () => {
           const data = {
             review_target: 'Calisa VII',
             review_summary: 'Nice place',
-            review_ratings: '{"hospitality":1,"price":2,"crowd":3,"cleanliness":4,"transport":5}',
+            review_full: '',
             review_hashtags: '',
             review_image: ''
           };
@@ -42,7 +42,7 @@ describe('review module', () => {
           const data = {
             review_target: 'Calisa VII',
             review_summary: 'Nice place',
-            review_ratings: '{"hospitality":1}',
+            review_full: 'Full text',
             review_hashtags: 'cool',
             review_image: '123'
           };
@@ -56,6 +56,7 @@ describe('review module', () => {
 
     expect(send).toHaveBeenCalled();
     const embed = send.mock.calls[0][0].embeds[0];
+    expect(embed.data.description).toMatch(/Full text/);
     expect(embed.data.description).toMatch(/#cool/);
     expect(embed.data.image.url).toBe('https://example.com/img.png');
   });
@@ -70,7 +71,7 @@ describe('review module', () => {
           const data = {
             review_target: 'Calisa VII',
             review_summary: 'Nice place',
-            review_ratings: '{"hospitality":1,"price":2,"crowd":3,"cleanliness":4,"transport":5}',
+            review_full: '',
             review_hashtags: '',
             review_image: ''
           };

--- a/commands/review.js
+++ b/commands/review.js
@@ -30,12 +30,11 @@ module.exports = {
       .setStyle(TextInputStyle.Short)
       .setRequired(true);
 
-    const ratingsInput = new TextInputBuilder()
-      .setCustomId('review_ratings')
-      .setLabel('Ratings JSON')
-      .setStyle(TextInputStyle.Short)
-      .setRequired(true)
-      .setPlaceholder('{ "hospitality":1, "price":2 }');
+    const fullTextInput = new TextInputBuilder()
+      .setCustomId('review_full')
+      .setLabel('Full Review (optional)')
+      .setStyle(TextInputStyle.Paragraph)
+      .setRequired(false);
 
     const hashtagsInput = new TextInputBuilder()
       .setCustomId('review_hashtags')
@@ -52,7 +51,7 @@ module.exports = {
     modal.addComponents(
       new ActionRowBuilder().addComponents(targetInput),
       new ActionRowBuilder().addComponents(summaryInput),
-      new ActionRowBuilder().addComponents(ratingsInput),
+      new ActionRowBuilder().addComponents(fullTextInput),
       new ActionRowBuilder().addComponents(hashtagsInput),
       new ActionRowBuilder().addComponents(imageInput)
     );

--- a/modules/review.js
+++ b/modules/review.js
@@ -6,15 +6,7 @@ async function handleReviewModal(interaction) {
 
   const target = interaction.fields.getTextInputValue('review_target');
   const summary = interaction.fields.getTextInputValue('review_summary');
-  const ratingsRaw = interaction.fields.getTextInputValue('review_ratings');
-
-  let ratings;
-  try {
-    ratings = JSON.parse(ratingsRaw);
-  } catch {
-    await interaction.reply({ content: '❌ Invalid ratings JSON.', ephemeral: true });
-    return;
-  }
+  const fullText = interaction.fields.getTextInputValue('review_full');
 
   const hashtags = hashtagsInput
     ? hashtagsInput
@@ -26,6 +18,7 @@ async function handleReviewModal(interaction) {
     : [];
 
   let description = summary;
+  if (fullText) description += `\n\n${fullText}`;
   if (hashtags.length) description += `\n\n${hashtags.join(' ')}`;
 
   const embed = new EmbedBuilder()
@@ -34,12 +27,6 @@ async function handleReviewModal(interaction) {
     .setDescription(description)
     .setColor(0x2c3e50);
 
-  const keys = ['hospitality', 'price', 'crowd', 'cleanliness', 'transport'];
-  for (const key of keys) {
-    if (ratings[key] !== undefined) {
-      embed.addFields({ name: key.charAt(0).toUpperCase() + key.slice(1), value: String(ratings[key]), inline: true });
-    }
-  }
 
 
   if (imageMessageId) {


### PR DESCRIPTION
## Summary
- remove numeric ratings from the review slash command
- allow optional full text field when submitting reviews
- update review modal handler to include full text
- adjust unit tests for new review fields

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688b474520d8832ea3d875053cae2f9a