### PR TITLE
Add Kaldur Prime travel flow

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ const { startNewsCycle } = require('./modules/news');
 const rotateStatus = require('./modules/status');
 const { startAdLoop } = require('./modules/ads');
 const { showCalisaMenu, handleCalisaOption } = require('./modules/calisa');
+const { showKaldurMenu, handleKaldurOption } = require('./modules/kaldur');
 const { handleReviewModal } = require('./modules/review');
 
 const client = new Client({
@@ -91,22 +92,57 @@ client.on('interactionCreate', async interaction => {
             return;
         }
 
+        // 🎯 KALDUR PRIME TICKET HANDLER
+        if (interaction.customId === 'kaldur_buy_ticket') {
+            const member = interaction.member;
+            const guild = interaction.guild;
+            const kaldurRole = guild.roles.cache.find(r => r.name === 'KALDUR PRIME');
+
+            if (!kaldurRole) {
+                await interaction.reply({ content: '❌ Kaldur role not found.', ephemeral: true });
+                return;
+            }
+
+            if (member.roles.cache.has(kaldurRole.id)) {
+                await interaction.reply({ content: '🎯 You already have a ticket to Kaldur Prime.', ephemeral: true });
+                return;
+            }
+
+            await member.roles.add(kaldurRole);
+
+            await interaction.channel.send({ content: `🎯 <@${member.id}> has departed for **Kaldur Prime**...` });
+
+            await showKaldurMenu(interaction);
+            return;
+        }
+
 
         // 🧭 CALISA OPTION + SUBPATH HANDLER
         if (scope === 'calisa' && (category.startsWith('option') || category.startsWith('mtn'))) {
             await handleCalisaOption(interaction);
             return;
         }
+
+        // 🏹 KALDUR OPTION HANDLER
+        if (scope === 'kaldur') {
+            await handleKaldurOption(interaction);
+            return;
+        }
     }
 
     // DESTINATION SELECT MENU
-    if (
-        interaction.isStringSelectMenu() &&
-        (interaction.customId === 'calisa_select_destination' ||
-         interaction.customId === 'calisa_select_mountain')
-    ) {
-        await handleCalisaOption(interaction);
-        return;
+    if (interaction.isStringSelectMenu()) {
+        if (
+            interaction.customId === 'calisa_select_destination' ||
+            interaction.customId === 'calisa_select_mountain'
+        ) {
+            await handleCalisaOption(interaction);
+            return;
+        }
+        if (interaction.customId.startsWith('kaldur_select_')) {
+            await handleKaldurOption(interaction);
+            return;
+        }
     }
 
     // REVIEW MODAL SUBMISSION

--- a/modules/ads.js
+++ b/modules/ads.js
@@ -30,16 +30,22 @@ async function postAd(client) {
       text: `Sponsored by ${ad.sponsor}`,
     });
 
-  // 🎫 Only for CALISA VII — show the BUY TICKET button
-  const isCalisa = ad.title.toLowerCase().includes("calisa");
-  const components = isCalisa
+  // 🎫 Trip ads show a BUY TICKET button
+  let ticketId = null;
+  if (ad.title.toLowerCase().includes("calisa")) {
+    ticketId = "calisa_buy_ticket";
+  } else if (ad.title.toLowerCase().includes("kaldur")) {
+    ticketId = "kaldur_buy_ticket";
+  }
+
+  const components = ticketId
     ? [
         new ActionRowBuilder().addComponents(
           new ButtonBuilder()
-            .setCustomId("calisa_buy_ticket")
+            .setCustomId(ticketId)
             .setLabel("🎫 Buy Ticket")
             .setStyle(ButtonStyle.Primary)
-        ),
+        )
       ]
     : [];
 

--- a/modules/kaldur.js
+++ b/modules/kaldur.js
@@ -1,0 +1,86 @@
+const {
+  EmbedBuilder,
+  ActionRowBuilder,
+  StringSelectMenuBuilder,
+} = require('discord.js');
+
+async function showKaldurMenu(interaction) {
+  const embed = new EmbedBuilder()
+    .setDescription(
+      '*No return. No mercy.*\n\n' +
+        'Kaldur Prime awaits beyond the veil of sanctioned space. ' +
+        'Ice storms flay metal. Megafauna roam ancient valleys. ' +
+        'Hunters vanish chasing glory.\n\n' +
+        '**Where will you hunt?**'
+    )
+    .setImage('https://i.imgur.com/WdZImBi.png')
+    .setColor(0x2c3e50);
+
+  const select = new StringSelectMenuBuilder()
+    .setCustomId('kaldur_select_destination')
+    .setPlaceholder('Choose your quarry')
+    .addOptions([
+      {
+        label: 'The Iron Citadel',
+        value: 'kaldur_option_citadel',
+        emoji: { id: '1399477691278692352' },
+      },
+      {
+        label: 'Ice Wastes',
+        value: 'kaldur_option_wastes',
+        emoji: { id: '1399477691278692352' },
+      },
+      {
+        label: 'Crystal Caverns',
+        value: 'kaldur_option_cavern',
+        emoji: { id: '1399477691278692352' },
+      },
+    ]);
+
+  const row = new ActionRowBuilder().addComponents(select);
+
+  await interaction.reply({ embeds: [embed], components: [row], ephemeral: true });
+}
+
+async function handleKaldurOption(interaction) {
+  const choice = interaction.isStringSelectMenu()
+    ? interaction.values[0]
+    : interaction.customId;
+
+  let text = '';
+  let img = null;
+
+  switch (choice) {
+    case 'kaldur_option_citadel':
+      text =
+        'You breach the rusted gates of the **Iron Citadel**. ' +
+        'Automated turrets track your every move. Few return from its halls.';
+      img = 'https://i.imgur.com/WdZImBi.png';
+      break;
+
+    case 'kaldur_option_wastes':
+      text =
+        'You trek across the **Ice Wastes**, where blizzards swallow sound and shadow.';
+      img = 'https://i.imgur.com/WdZImBi.png';
+      break;
+
+    case 'kaldur_option_cavern':
+      text =
+        'You descend into the **Crystal Caverns**, light refracting into endless shards.';
+      img = 'https://i.imgur.com/WdZImBi.png';
+      break;
+
+    default:
+      await interaction.update({ content: '⚠️ Unknown option.', components: [] });
+      return;
+  }
+
+  const embed = new EmbedBuilder()
+    .setDescription(text)
+    .setImage(img)
+    .setColor(0x2c3e50);
+
+  await interaction.update({ embeds: [embed], components: [] });
+}
+
+module.exports = { showKaldurMenu, handleKaldurOption };


### PR DESCRIPTION
## Summary
- add new travel module for Kaldur Prime
- show Buy Ticket button for Kaldur ads
- route Kaldur ticket and sub-options
- handle select menus for Kaldur

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688c9528e63c832eacf8d9fd27bf88b7