### PR TITLE
Add tests for Kaldur adventure

### DIFF
--- a/__tests__/kaldur.test.js
+++ b/__tests__/kaldur.test.js
@@ -1,0 +1,69 @@
+const { ActionRowBuilder, StringSelectMenuBuilder } = require('discord.js');
+const { handleKaldurOption } = require('../modules/kaldur');
+
+describe('kaldur module', () => {
+  test('disables original components after selection', async () => {
+    const select = new StringSelectMenuBuilder()
+      .setCustomId('menu')
+      .addOptions({ label: 'opt', value: 'kaldur_option_camp' });
+    const row = new ActionRowBuilder().addComponents(select);
+
+    const interaction = {
+      isStringSelectMenu: () => true,
+      values: ['kaldur_option_camp'],
+      update: jest.fn().mockResolvedValue(),
+      message: { components: [row] },
+    };
+
+    await handleKaldurOption(interaction);
+
+    const components = interaction.update.mock.calls[0][0].components;
+    expect(components[0].components[0].toJSON().disabled).toBe(true);
+  });
+
+  test('hunt option shows a select menu', async () => {
+    const select = new StringSelectMenuBuilder()
+      .setCustomId('menu')
+      .addOptions({ label: 'hunt', value: 'kaldur_option_hunt' });
+    const row = new ActionRowBuilder().addComponents(select);
+
+    const interaction = {
+      isStringSelectMenu: () => true,
+      values: ['kaldur_option_hunt'],
+      update: jest.fn().mockResolvedValue(),
+      message: { components: [row] },
+    };
+
+    await handleKaldurOption(interaction);
+
+    const components = interaction.update.mock.calls[0][0].components;
+    expect(components).toHaveLength(2);
+    expect(components[0].components[0].toJSON().disabled).toBe(true);
+    const menu = components[1].components[0];
+    expect(menu).toBeInstanceOf(StringSelectMenuBuilder);
+  });
+
+  test('track option ends hunt without new menus', async () => {
+    const rootSelect = new StringSelectMenuBuilder()
+      .setCustomId('menu')
+      .addOptions({ label: 'hunt', value: 'kaldur_option_hunt' });
+    const subSelect = new StringSelectMenuBuilder()
+      .setCustomId('sub')
+      .addOptions({ label: 'track', value: 'kaldur_hunt_track' });
+    const row1 = new ActionRowBuilder().addComponents(rootSelect);
+    const row2 = new ActionRowBuilder().addComponents(subSelect);
+
+    const interaction = {
+      isStringSelectMenu: () => true,
+      values: ['kaldur_hunt_track'],
+      update: jest.fn().mockResolvedValue(),
+      message: { components: [row1, row2] },
+    };
+
+    await handleKaldurOption(interaction);
+
+    const components = interaction.update.mock.calls[0][0].components;
+    expect(components).toHaveLength(2);
+    expect(components.every(r => r.components[0].toJSON().disabled)).toBe(true);
+  });
+});

--- a/modules/kaldur.js
+++ b/modules/kaldur.js
@@ -1,0 +1,77 @@
+const {
+  EmbedBuilder,
+  ActionRowBuilder,
+  StringSelectMenuBuilder
+} = require('discord.js');
+
+async function showKaldurMenu(interaction) {
+  const embed = new EmbedBuilder()
+    .setDescription(
+      '*Hypertrip awaits on Kaldur Prime.*\n\nChoose your destiny.'
+    )
+    .setImage('https://i.imgur.com/WdZImBi.png')
+    .setColor(0x2c3e50);
+
+  const select = new StringSelectMenuBuilder()
+    .setCustomId('kaldur_select_destination')
+    .setPlaceholder('Choose your path')
+    .addOptions([
+      { label: 'Base Camp', value: 'kaldur_option_camp' },
+      { label: 'Hunting Grounds', value: 'kaldur_option_hunt' },
+      { label: 'Abort Hunt', value: 'kaldur_option_end' }
+    ]);
+
+  const row = new ActionRowBuilder().addComponents(select);
+  await interaction.reply({ embeds: [embed], components: [row], ephemeral: true });
+}
+
+function disableComponents(rows) {
+  return rows.map(r => {
+    const row = ActionRowBuilder.from(r);
+    row.components = row.components.map(c => {
+      if (typeof c.setDisabled === 'function') c.setDisabled(true);
+      return c;
+    });
+    return row;
+  });
+}
+
+async function handleKaldurOption(interaction) {
+  const choice = interaction.isStringSelectMenu()
+    ? interaction.values[0]
+    : interaction.customId;
+  let text = '';
+  let components = [];
+
+  switch (choice) {
+    case 'kaldur_option_camp':
+      text = 'You set up a base camp amid the cold spires of Kaldur Prime.';
+      break;
+    case 'kaldur_option_hunt':
+      text = 'The hunt begins in the obsidian wilds.';
+      const huntSelect = new StringSelectMenuBuilder()
+        .setCustomId('kaldur_select_hunt')
+        .setPlaceholder('Next step')
+        .addOptions([
+          { label: 'Track the Beast', value: 'kaldur_hunt_track' },
+          { label: 'Return to Camp', value: 'kaldur_option_end' }
+        ]);
+      components.push(new ActionRowBuilder().addComponents(huntSelect));
+      break;
+    case 'kaldur_hunt_track':
+      text = 'You stalk the legendary beast through frozen canyons.';
+      break;
+    case 'kaldur_option_end':
+      text = 'You abandon the hunt and return home.';
+      break;
+    default:
+      await interaction.update({ content: '⚠️ Unknown option.', components: [] });
+      return;
+  }
+
+  const disabled = disableComponents(interaction.message.components);
+  const embed = new EmbedBuilder().setDescription(text).setColor(0x2c3e50);
+  await interaction.update({ embeds: [embed], components: disabled.concat(components) });
+}
+
+module.exports = { showKaldurMenu, handleKaldurOption };


### PR DESCRIPTION
## Summary
- add new Kaldur module mirroring Calisa
- ensure menu interactions disable previous components
- test multi-step selections in `__tests__/kaldur.test.js`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688c952e65c4832e87fa7a455349bad5