### PR TITLE
Add Kaldur Prime travel flow and ticket handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ const { startNewsCycle } = require('./modules/news');
 const rotateStatus = require('./modules/status');
 const { startAdLoop } = require('./modules/ads');
 const { showCalisaMenu, handleCalisaOption } = require('./modules/calisa');
+const { showKaldurMenu, handleKaldurOption } = require('./modules/kaldur');
 const { handleReviewModal } = require('./modules/review');
 
 const client = new Client({
@@ -91,10 +92,40 @@ client.on('interactionCreate', async interaction => {
             return;
         }
 
+        // 🎫 KALDUR PRIME TICKET HANDLER
+        if (interaction.customId === 'kaldur_buy_ticket') {
+            const member = interaction.member;
+            const guild = interaction.guild;
+            const kaldurRole = guild.roles.cache.find(r => r.name === 'KALDUR PRIME');
+
+            if (!kaldurRole) {
+                await interaction.reply({ content: '❌ Kaldur role not found.', ephemeral: true });
+                return;
+            }
+
+            if (member.roles.cache.has(kaldurRole.id)) {
+                await interaction.reply({ content: '🗡️ You already have a ticket to Kaldur Prime.', ephemeral: true });
+                return;
+            }
+
+            await member.roles.add(kaldurRole);
+
+            await interaction.channel.send({ content: `🗡️ <@${member.id}> has departed for **Kaldur Prime**...` });
+
+            await showKaldurMenu(interaction);
+            return;
+        }
+
 
         // 🧭 CALISA OPTION + SUBPATH HANDLER
         if (scope === 'calisa' && (category.startsWith('option') || category.startsWith('mtn'))) {
             await handleCalisaOption(interaction);
+            return;
+        }
+
+        // 🗡️ KALDUR OPTION HANDLER
+        if (scope === 'kaldur' && (category.startsWith('option') || category.startsWith('hunt'))) {
+            await handleKaldurOption(interaction);
             return;
         }
     }
@@ -106,6 +137,15 @@ client.on('interactionCreate', async interaction => {
          interaction.customId === 'calisa_select_mountain')
     ) {
         await handleCalisaOption(interaction);
+        return;
+    }
+
+    if (
+        interaction.isStringSelectMenu() &&
+        (interaction.customId === 'kaldur_select_destination' ||
+         interaction.customId === 'kaldur_select_hunt')
+    ) {
+        await handleKaldurOption(interaction);
         return;
     }
 

--- a/modules/ads.js
+++ b/modules/ads.js
@@ -33,7 +33,7 @@ async function postAd(client) {
   // 🎫 Show the BUY TICKET button for CALISA or KALDUR ads
   const title = ad.title.toLowerCase();
   const isCalisa = title.includes("calisa");
-  const isKaldur = title.includes("kaldur");
+  const isKaldur = title.includes("kaldur"); // match "kaldur prime" as well
   const components = isCalisa || isKaldur
     ? [
         new ActionRowBuilder().addComponents(

--- a/modules/kaldur.js
+++ b/modules/kaldur.js
@@ -4,6 +4,8 @@ const {
   StringSelectMenuBuilder
 } = require('discord.js');
 
+// Kaldur Prime adventure flow utilities
+
 async function showKaldurMenu(interaction) {
   const embed = new EmbedBuilder()
     .setDescription(
@@ -62,7 +64,7 @@ async function handleKaldurOption(interaction) {
       text = 'You stalk the legendary beast through frozen canyons.';
       break;
     case 'kaldur_option_end':
-      text = 'You abandon the hunt and return home.';
+      text = 'You abandon the hunt and return home with tales of near glory.';
       break;
     default:
       await interaction.update({ content: '⚠️ Unknown option.', components: [] });


### PR DESCRIPTION
## Summary
- integrate Kaldur Prime travel into the main bot
- display ticket button for Kaldur ads
- tweak text in Kaldur adventure module

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688c99f68734832eb67d70d782fa5fc0