### PR TITLE
Add ticket button test for Kaldur ad

### DIFF
--- a/__tests__/ads.test.js
+++ b/__tests__/ads.test.js
@@ -1,0 +1,40 @@
+const { ActionRowBuilder } = require('discord.js');
+const { postAd } = require('../modules/ads');
+
+jest.mock('../modules/cache', () => ({
+  getAds: jest.fn(),
+}));
+
+const { getAds } = require('../modules/cache');
+
+describe('ads module', () => {
+  test('adds ticket button for Kaldur ad', async () => {
+    process.env.GUILD_ID = '1';
+    process.env.NEWS_CHANNEL_NAME = 'news-feed';
+
+    const send = jest.fn().mockResolvedValue();
+    const channel = { name: 'news-feed', isTextBased: () => true, send };
+    const channels = { find: jest.fn(() => channel) };
+    const guild = { name: 'Test', channels: { fetch: jest.fn().mockResolvedValue(channels) } };
+    const client = { guilds: { fetch: jest.fn().mockResolvedValue(guild) } };
+
+    getAds.mockReturnValue([
+      {
+        title: 'KALDUR PRIME',
+        text: 'Hunt awaits',
+        image: 'http://example.com/img.png',
+        sponsor: 'Hypertrip',
+      },
+    ]);
+
+    await postAd(client);
+
+    expect(send).toHaveBeenCalled();
+    const components = send.mock.calls[0][0].components;
+    expect(components).toHaveLength(1);
+    const row = components[0];
+    expect(row).toBeInstanceOf(ActionRowBuilder);
+    const btn = row.components[0];
+    expect(btn.toJSON().custom_id).toBe('kaldur_buy_ticket');
+  });
+});


### PR DESCRIPTION
## Summary
- add new `ads.test.js` verifying that `postAd` attaches the `kaldur_buy_ticket` button

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688c9a028a34832e8272122c4d1b01e1