### PR TITLE
Sync kaldur module with tests

### DIFF
--- a/modules/kaldur.js
+++ b/modules/kaldur.js
@@ -64,7 +64,8 @@ async function handleKaldurOption(interaction) {
       text = 'You stalk the legendary beast through frozen canyons.';
       break;
     case 'kaldur_option_end':
-      text = 'You abandon the hunt and return home with tales of near glory.';
+      // Keep message brief so tests can validate exact copy
+      text = 'You abandon the hunt and return home.';
       break;
     default:
       await interaction.update({ content: '⚠️ Unknown option.', components: [] });


### PR DESCRIPTION
## Summary
- match Kaldur's ending text to test expectations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688c9e921754832e828944eca8bfc330