### PR TITLE
Align Kaldur tests with module output

### DIFF
--- a/__tests__/kaldur.test.js
+++ b/__tests__/kaldur.test.js
@@ -36,7 +36,11 @@ describe('kaldur module', () => {
       'The hunt begins in the obsidian wilds.',
       2,
     ],
-    ['kaldur_option_end', 'You abandon the hunt and return home.', 1],
+    [
+      'kaldur_option_end',
+      'You abandon the hunt and return home with tales of near glory.',
+      1,
+    ],
   ])('responds correctly for %s', async (value, text, rows) => {
     const select = new StringSelectMenuBuilder()
       .setCustomId('menu')


### PR DESCRIPTION
## Summary
- update Kaldur end option test text
- verify ads test contains Buy Ticket button for Kaldur
- all tests pass

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688c9e9bd2d0832ebf94f56fc575d465