### PR TITLE
Update Kaldur tests for new flow

### DIFF
--- a/__tests__/kaldur.test.js
+++ b/__tests__/kaldur.test.js
@@ -3,9 +3,28 @@ const {
   StringSelectMenuBuilder,
   EmbedBuilder,
 } = require('discord.js');
-const { handleKaldurOption } = require('../modules/kaldur');
+const { showKaldurMenu, handleKaldurOption } = require('../modules/kaldur');
 
 describe('kaldur module', () => {
+  test('showKaldurMenu sends intro embed with choices', async () => {
+    const reply = jest.fn().mockResolvedValue();
+    const interaction = { reply };
+
+    await showKaldurMenu(interaction);
+
+    const { embeds, components } = reply.mock.calls[0][0];
+    expect(embeds[0]).toBeInstanceOf(EmbedBuilder);
+    expect(embeds[0].data.description).toBe(
+      '*Hypertrip returns to the ice world of Kaldur Prime.*\n\nChoose your path.'
+    );
+    const options = components[0].components[0].options.map(o => o.data.value);
+    expect(options).toEqual([
+      'kaldur_option_camp',
+      'kaldur_option_hunt',
+      'kaldur_option_pillage',
+      'kaldur_option_end'
+    ]);
+  });
   test('selecting a destination disables menu components', async () => {
     const select = new StringSelectMenuBuilder()
       .setCustomId('menu')
@@ -38,7 +57,7 @@ describe('kaldur module', () => {
     ],
     [
       'kaldur_option_end',
-      'You abandon the hunt and return home with tales of near glory.',
+      'You abandon the hunt and return home.',
       1,
     ],
   ])('responds correctly for %s', async (value, text, rows) => {
@@ -65,5 +84,56 @@ describe('kaldur module', () => {
       const menu = components[1].components[0];
       expect(menu).toBeInstanceOf(StringSelectMenuBuilder);
     }
+  });
+
+  test('deeper hunt track option disables all components', async () => {
+    const destSelect = new StringSelectMenuBuilder()
+      .setCustomId('kaldur_select_destination')
+      .addOptions({ label: 'camp', value: 'kaldur_option_hunt' });
+    const huntSelect = new StringSelectMenuBuilder()
+      .setCustomId('kaldur_select_hunt')
+      .addOptions({ label: 'track', value: 'kaldur_hunt_track' });
+    const row1 = new ActionRowBuilder().addComponents(destSelect);
+    const row2 = new ActionRowBuilder().addComponents(huntSelect);
+    const interaction = {
+      isStringSelectMenu: () => true,
+      values: ['kaldur_hunt_track'],
+      update: jest.fn().mockResolvedValue(),
+      message: { components: [row1, row2] },
+    };
+
+    await handleKaldurOption(interaction);
+
+    const { embeds, components } = interaction.update.mock.calls[0][0];
+    expect(embeds[0].data.description).toBe(
+      'You stalk the legendary beast through frozen canyons.'
+    );
+    expect(components[0].components[0].toJSON().disabled).toBe(true);
+    expect(components[1].components[0].toJSON().disabled).toBe(true);
+  });
+
+  test('pillage option grants role', async () => {
+    const destSelect = new StringSelectMenuBuilder()
+      .setCustomId('kaldur_select_destination')
+      .addOptions({ label: 'camp', value: 'kaldur_option_hunt' });
+    const huntSelect = new StringSelectMenuBuilder()
+      .setCustomId('kaldur_select_hunt')
+      .addOptions({ label: 'pillage', value: 'kaldur_hunt_pillage' });
+    const row1 = new ActionRowBuilder().addComponents(destSelect);
+    const row2 = new ActionRowBuilder().addComponents(huntSelect);
+    const member = { roles: { add: jest.fn().mockResolvedValue(), cache: new Map() } };
+    const guild = { roles: { cache: { find: jest.fn(() => ({ id: '1' })) } } };
+    const interaction = {
+      isStringSelectMenu: () => true,
+      values: ['kaldur_hunt_pillage'],
+      update: jest.fn().mockResolvedValue(),
+      message: { components: [row1, row2] },
+      member,
+      guild,
+    };
+
+    await handleKaldurOption(interaction);
+
+    expect(member.roles.add).toHaveBeenCalledWith(expect.objectContaining({ id: '1' }));
   });
 });

--- a/modules/kaldur.js
+++ b/modules/kaldur.js
@@ -9,7 +9,7 @@ const {
 async function showKaldurMenu(interaction) {
   const embed = new EmbedBuilder()
     .setDescription(
-      '*Hypertrip awaits on Kaldur Prime.*\n\nChoose your destiny.'
+      '*Hypertrip returns to the ice world of Kaldur Prime.*\n\nChoose your path.'
     )
     .setImage('https://i.imgur.com/WdZImBi.png')
     .setColor(0x2c3e50);
@@ -20,6 +20,7 @@ async function showKaldurMenu(interaction) {
     .addOptions([
       { label: 'Base Camp', value: 'kaldur_option_camp' },
       { label: 'Hunting Grounds', value: 'kaldur_option_hunt' },
+      { label: 'Pillage Outpost', value: 'kaldur_option_pillage' },
       { label: 'Abort Hunt', value: 'kaldur_option_end' }
     ]);
 
@@ -56,12 +57,29 @@ async function handleKaldurOption(interaction) {
         .setPlaceholder('Next step')
         .addOptions([
           { label: 'Track the Beast', value: 'kaldur_hunt_track' },
+          { label: 'Pillage the Ruins', value: 'kaldur_hunt_pillage' },
           { label: 'Return to Camp', value: 'kaldur_option_end' }
         ]);
       components.push(new ActionRowBuilder().addComponents(huntSelect));
       break;
+    case 'kaldur_option_pillage':
+      text = 'You storm the derelict outpost, ready to pillage.';
+      break;
     case 'kaldur_hunt_track':
       text = 'You stalk the legendary beast through frozen canyons.';
+      break;
+    case 'kaldur_hunt_pillage':
+      text = 'You loot the ruins, claiming trophies for the Dominion.';
+      try {
+        const role = interaction.guild.roles.cache.find(
+          r => r.name === 'KALDUR PILLAGE'
+        );
+        if (role && !interaction.member.roles.cache.has(role.id)) {
+          await interaction.member.roles.add(role);
+        }
+      } catch (err) {
+        console.warn('⚠️ Could not assign pillage role:', err.message);
+      }
       break;
     case 'kaldur_option_end':
       // Keep message brief so tests can validate exact copy


### PR DESCRIPTION
## Summary
- update Kaldur intro text and add new pillage option
- expand test coverage for deeper Kaldur branches
- verify pillage role is granted on pillage choice

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688caa366c28832eb765b0e244bac200