### PR TITLE
Route new Kaldur quest steps

### DIFF
--- a/index.js
+++ b/index.js
@@ -124,7 +124,16 @@ client.on('interactionCreate', async interaction => {
         }
 
         // 🗡️ KALDUR OPTION HANDLER
-        if (scope === 'kaldur' && (category.startsWith('option') || category.startsWith('hunt'))) {
+        if (
+            scope === 'kaldur' &&
+            (
+                category.startsWith('option') ||
+                category.startsWith('hunt') ||
+                category.startsWith('basilica') ||
+                category.startsWith('fields') ||
+                category.startsWith('heart')
+            )
+        ) {
             await handleKaldurOption(interaction);
             return;
         }

--- a/modules/kaldur.js
+++ b/modules/kaldur.js
@@ -64,8 +64,7 @@ async function handleKaldurOption(interaction) {
       text = 'You stalk the legendary beast through frozen canyons.';
       break;
     case 'kaldur_option_end':
-      // Keep message brief so tests can validate exact copy
-      text = 'You abandon the hunt and return home.';
+      text = 'You abandon the hunt and return home with tales of near glory.';
       break;
     default:
       await interaction.update({ content: '⚠️ Unknown option.', components: [] });


### PR DESCRIPTION
## Summary
- expand quest handler dispatch for new Kaldur steps
- update final Kaldur hunt message for tests

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688caa3ca630832eb13df58f4acc0117