### PR TITLE
Add Kaldur pillage role handling

### DIFF
--- a/modules/kaldur.js
+++ b/modules/kaldur.js
@@ -64,8 +64,7 @@ async function handleKaldurOption(interaction) {
       text = 'You stalk the legendary beast through frozen canyons.';
       break;
     case 'kaldur_option_end':
-      // Keep message brief so tests can validate exact copy
-      text = 'You abandon the hunt and return home.';
+      text = 'You abandon the hunt and return home with tales of near glory.';
       break;
     default:
       await interaction.update({ content: '⚠️ Unknown option.', components: [] });
@@ -75,6 +74,33 @@ async function handleKaldurOption(interaction) {
   const disabled = disableComponents(interaction.message.components);
   const embed = new EmbedBuilder().setDescription(text).setColor(0x2c3e50);
   await interaction.update({ embeds: [embed], components: disabled.concat(components) });
+
+  if (/murmuring fields.*pillage/i.test(text)) {
+    let pillageRole = interaction.guild.roles.cache.find(
+      r => r.name === 'KALDUR PILLAGE'
+    );
+    if (!pillageRole) {
+      try {
+        pillageRole = await interaction.guild.roles.create({ name: 'KALDUR PILLAGE' });
+      } catch (err) {
+        console.warn('⚠️ Could not create pillage role:', err.message);
+      }
+    }
+
+    try {
+      if (pillageRole && !interaction.member.roles.cache.has(pillageRole.id)) {
+        await interaction.member.roles.add(pillageRole);
+      }
+    } catch (err) {
+      console.warn('⚠️ Could not assign pillage role:', err.message);
+    }
+
+    await interaction.followUp({
+      content:
+        'Smoke rises from the Murmuring Fields. Your spoils are secure.\n\nKaldur Pillage role granted!',
+      ephemeral: true,
+    });
+  }
 }
 
 module.exports = { showKaldurMenu, handleKaldurOption };


### PR DESCRIPTION
## Summary
- detect Murmuring Fields pillage result in `handleKaldurOption`
- award the **KALDUR PILLAGE** role and send a follow-up message
- align end-of-hunt text with tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688caa40e8e8832eb074da6e55d22fbb