### PR TITLE
Fix Kaldur menu routing

### DIFF
--- a/index.js
+++ b/index.js
@@ -149,11 +149,8 @@ client.on('interactionCreate', async interaction => {
         return;
     }
 
-    if (
-        interaction.isStringSelectMenu() &&
-        (interaction.customId === 'kaldur_select_destination' ||
-         interaction.customId === 'kaldur_select_hunt')
-    ) {
+    if (interaction.isStringSelectMenu() &&
+        interaction.customId.startsWith('kaldur_select_')) {
         await handleKaldurOption(interaction);
         return;
     }


### PR DESCRIPTION
## Summary
- route any select option with `kaldur_select_` prefix to Kaldur option handler

## Testing
- `npm test` *(fails: kaldur.test.js)*
- `node index.js` *(fails: TokenInvalid)*

------
https://chatgpt.com/codex/tasks/task_e_688cd492f784832eb63bfcabc6af0aa1