### PR TITLE
feat: add pillage follow-up message

### DIFF
--- a/modules/kaldur.js
+++ b/modules/kaldur.js
@@ -465,6 +465,14 @@ async function handleKaldurOption(interaction) {
       } catch (err) {
         console.warn('⚠️ Could not assign pillage role:', err.message);
       }
+
+      await interaction.followUp({
+        content:
+          'Weeks later, you liquidate the idol discreetly through a frontier broker. ' +
+          'The proceeds seed a quiet investment portfolio: modular habitats, mining futures, low-orbit grain patents. ' +
+          'The income is steady. Respectable. KALDUR PILLAGE role granted!',
+        ephemeral: true,
+      });
       break;
     }
 


### PR DESCRIPTION
## Summary
- send an ephemeral message after the `kaldur_quiet_pillage` choice

## Testing
- `npm test` *(failing: kaldur module tests fail due to outdated expectations)*

------
https://chatgpt.com/codex/tasks/task_e_688de3a121d0832e9c3b1aad0065b1ba