### PR TITLE
Increase news cycle delay to 5-6 hours

### DIFF
--- a/modules/news.js
+++ b/modules/news.js
@@ -1,8 +1,8 @@
 const { getNews } = require('./cache');
 
 function getRandomDelay() {
-  const min = 2 * 60 * 60 * 1000; // 2 hours
-  const max = 3 * 60 * 60 * 1000; // 3 hours
+  const min = 5 * 60 * 60 * 1000; // 5 hours
+  const max = 6 * 60 * 60 * 1000; // 6 hours
   return Math.floor(Math.random() * (max - min) + min);
 }
 


### PR DESCRIPTION
## Summary
- widen news cycle random delay from 2-3 hours to 5-6 hours
- retain scheduling of news posts with `setInterval` and `getRandomDelay`

## Testing
- `npm test` *(fails: kaldur module tests)*

------
https://chatgpt.com/codex/tasks/task_e_689209feb540832eb974f0aa53a20e04