### PR TITLE
feat: support rz alias for Razathaar quest

### DIFF
--- a/__tests__/razathaarQuest.test.js
+++ b/__tests__/razathaarQuest.test.js
@@ -1,0 +1,43 @@
+const mockOn = jest.fn();
+const mockClient = {
+  on: mockOn,
+  once: jest.fn(),
+  login: jest.fn(),
+  guilds: { fetch: jest.fn() },
+};
+
+jest.mock('fs', () => ({ readdirSync: () => [] }));
+
+jest.mock('discord.js', () => ({
+  Client: jest.fn(() => mockClient),
+  GatewayIntentBits: {},
+  Collection: class {},
+}));
+
+const mockHandleRazathaarOption = jest.fn();
+
+jest.mock('../modules/razathaarQuest', () => ({
+  showRazathaarMenu: jest.fn(),
+  handleRazathaarOption: mockHandleRazathaarOption,
+}));
+
+jest.mock('../modules/calisa', () => ({ showCalisaMenu: jest.fn(), handleCalisaOption: jest.fn() }));
+jest.mock('../modules/kaldur', () => ({ showKaldurMenu: jest.fn(), handleKaldurOption: jest.fn() }));
+jest.mock('../modules/news', () => ({ startNewsCycle: jest.fn() }));
+jest.mock('../modules/status', () => jest.fn());
+jest.mock('../modules/ads', () => ({ startAdLoop: jest.fn() }));
+jest.mock('../modules/review', () => ({ handleReviewModal: jest.fn() }));
+
+describe('razathaar quest interaction routing', () => {
+  test('dispatches to handleRazathaarOption for rz_ select menus', async () => {
+    require('../index');
+    const interactionHandler = mockOn.mock.calls.find(call => call[0] === 'interactionCreate')[1];
+    const interaction = {
+      isButton: () => false,
+      isStringSelectMenu: () => true,
+      customId: 'rz_d1_select',
+    };
+    await interactionHandler(interaction);
+    expect(mockHandleRazathaarOption).toHaveBeenCalledWith(interaction);
+  });
+});

--- a/index.js
+++ b/index.js
@@ -148,7 +148,7 @@ client.on('interactionCreate', async interaction => {
         }
 
         // 📦 RAZATHAAR OPTION HANDLER
-        if (scope === 'razathaar') {
+        if (scope === 'razathaar' || scope === 'rz') {
             await handleRazathaarOption(interaction);
             return;
         }
@@ -171,7 +171,7 @@ client.on('interactionCreate', async interaction => {
     }
 
     if (interaction.isStringSelectMenu() &&
-        interaction.customId.startsWith('razathaar_')) {
+        (interaction.customId.startsWith('razathaar_') || interaction.customId.startsWith('rz_'))) {
         await handleRazathaarOption(interaction);
         return;
     }


### PR DESCRIPTION
## Summary
- allow `rz` prefix for Razathaar quest buttons and select menus
- add a unit test ensuring `rz_` IDs dispatch to Razathaar handler

## Testing
- `npm test` *(fails: kaldur.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_6895ec235024832eb8c0d511ffa86f72