### PR TITLE
fix: assign razathaar shadow role

### DIFF
--- a/modules/razathaarQuest.js
+++ b/modules/razathaarQuest.js
@@ -501,9 +501,9 @@ async function handleRazathaarOption(interaction) {
           )
           .setFooter({ text: footer('Aftermath', flags) });
 
-        // grant smuggler role
+        // grant RAZATHAAR SHADOW role
         followUp = { content: 'Role granted: **RAZATHAAR SHADOW**. Access to mirage‑glass.', ephemeral: true };
-        await grantRole(interaction, 'RAZATHAAR SHADOW‑LANE CONTRACTOR');
+        await grantRole(interaction, 'RAZATHAAR SHADOW');
       } else {
         // choose a tailored fail-forward ending by missing category
         const need = [


### PR DESCRIPTION
## Summary
- ensure Night 3 quest completion grants RAZATHAAR SHADOW role

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896203c7c28832e935f2bb6e82f9363