### PR TITLE
Prevent restarting Razathaar quest when role already assigned

### DIFF
--- a/index.js
+++ b/index.js
@@ -128,9 +128,12 @@ client.on('interactionCreate', async interaction => {
                 return;
             }
 
-            if (!member.roles.cache.has(razathaarRole.id)) {
-                await member.roles.add(razathaarRole);
+            if (member.roles.cache.has(razathaarRole.id)) {
+                await interaction.reply({ content: '🚫 You cannot restart the Razathaar quest.', ephemeral: true });
+                return;
             }
+
+            await member.roles.add(razathaarRole);
 
             await interaction.channel.send({ content: `🚚 <@${member.id}> has accepted a Razathaar freight contract...` });
             await showRazathaarMenu(interaction);


### PR DESCRIPTION
## Summary
- avoid reinitializing Razathaar quest if user already has RAZATHAAR role
- grant quest role and start quest only when missing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689621429f34832ea54ca3f532f51c9b