### PR TITLE
Remove bonus cover from Nomad lead

### DIFF
--- a/__tests__/razathaarQuest.night3.test.js
+++ b/__tests__/razathaarQuest.night3.test.js
@@ -1,0 +1,38 @@
+const { handleRazathaarOption } = require('../modules/razathaarQuest');
+
+describe('Night 3 resolution', () => {
+  test('succeeds with contact, corridor, and cover', async () => {
+    const update = jest.fn().mockResolvedValue();
+    const followUp = jest.fn().mockResolvedValue();
+    const interaction = {
+      isStringSelectMenu: () => false,
+      isButton: () => true,
+      customId: 'rz_night|CN|RB|GLC',
+      update,
+      followUp,
+      inGuild: () => false,
+    };
+
+    await handleRazathaarOption(interaction);
+    const embed = update.mock.calls[0][0].embeds[0];
+    expect(embed.data.title).toBe('The Sere Auction');
+  });
+
+  test('fails when a cover is missing', async () => {
+    const update = jest.fn().mockResolvedValue();
+    const followUp = jest.fn().mockResolvedValue();
+    const interaction = {
+      isStringSelectMenu: () => false,
+      isButton: () => true,
+      customId: 'rz_night|CN|RB',
+      update,
+      followUp,
+      inGuild: () => false,
+    };
+
+    await handleRazathaarOption(interaction);
+    const embed = update.mock.calls[0][0].embeds[0];
+    expect(embed.data.title).toBe('Audit Hall, Dawn');
+    expect(embed.data.description).toContain('a **Cover**');
+  });
+});

--- a/modules/razathaarQuest.js
+++ b/modules/razathaarQuest.js
@@ -187,13 +187,13 @@ async function handleRazathaarOption(interaction) {
     }
 
     case choice === 'rz_d1_nomad': {
-      const flags = ['CN', 'CL']; // Contact: Nomad and Cover: Lattice Token
+      const flags = ['CN']; // Contact: Nomad
       embed = new EmbedBuilder()
         .setColor(0x2c3e50)
         .setImage('https://i.imgur.com/WKuuxhZ.png')
         .setTitle('Wind‑singers’ Camp')
         .setDescription(
-          'The Iktari matriarch loops a **lattice token** around your wrist. "With this, our caravans let you pass," she says. ' +
+          'The Iktari matriarch listens from behind veils. "Our caravans keep their own counsel," she says, yet you trade names with her nephew. ' +
           'They speak of a *Blue Hour* when the storm blinds machines.\n\n' +
           '**Day Two?**'
         )


### PR DESCRIPTION
## Summary
- Nomad day-one path now grants only a contact flag and no implied lattice token cover
- Add Night 3 tests to ensure the quest requires a contact, corridor, and cover for success

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689622adfc3c832ea691d87b3817941c