### PR TITLE
Defer Razathaar quest start and log failures

### DIFF
--- a/__tests__/razathaarQuest.test.js
+++ b/__tests__/razathaarQuest.test.js
@@ -62,10 +62,12 @@ describe('razathaar quest interaction routing', () => {
       member,
       guild,
       channel,
+      deferReply: jest.fn().mockResolvedValue(),
     };
 
     await interactionHandler(interaction);
 
+    expect(interaction.deferReply).toHaveBeenCalledWith({ ephemeral: true });
     expect(member.roles.add).toHaveBeenCalledWith(role);
     expect(channel.send).toHaveBeenCalledWith({ content: `🚚 <@${member.id}> has accepted a Razathaar freight contract...` });
     expect(mockShowRazathaarMenu).toHaveBeenCalledWith(interaction);

--- a/index.js
+++ b/index.js
@@ -133,10 +133,28 @@ client.on('interactionCreate', async interaction => {
                 return;
             }
 
-            await member.roles.add(razathaarRole);
+            try {
+                await interaction.deferReply({ ephemeral: true });
+                await member.roles.add(razathaarRole);
 
-            await interaction.channel.send({ content: `🚚 <@${member.id}> has accepted a Razathaar freight contract...` });
-            await showRazathaarMenu(interaction);
+                await interaction.channel.send({
+                    content: `🚚 <@${member.id}> has accepted a Razathaar freight contract...`
+                });
+                await showRazathaarMenu(interaction);
+            } catch (error) {
+                console.error('❌ Failed to start Razathaar quest', error);
+                if (interaction.deferred || interaction.replied) {
+                    await interaction.editReply({
+                        content: '⚠️ Could not start the Razathaar quest.',
+                        ephemeral: true
+                    }).catch(console.error);
+                } else {
+                    await interaction.reply({
+                        content: '⚠️ Could not start the Razathaar quest.',
+                        ephemeral: true
+                    }).catch(console.error);
+                }
+            }
             return;
         }
 

--- a/modules/razathaarQuest.js
+++ b/modules/razathaarQuest.js
@@ -103,11 +103,26 @@ async function showRazathaarMenu(interaction) {
       }
     );
 
-  await interaction.reply({
+  const payload = {
     embeds: [embed],
     components: [new ActionRowBuilder().addComponents(d1)],
-    ephemeral: true,
-  });
+  };
+
+  try {
+    if (interaction.deferred) {
+      await interaction.editReply(payload);
+    } else {
+      await interaction.reply({ ...payload, ephemeral: true });
+    }
+  } catch (error) {
+    console.error('❌ Failed to show Razathaar menu', error);
+    const failPayload = { content: '⚠️ Failed to show Razathaar menu.' };
+    if (interaction.deferred || interaction.replied) {
+      await interaction.editReply(failPayload).catch(console.error);
+    } else {
+      await interaction.reply({ ...failPayload, ephemeral: true }).catch(console.error);
+    }
+  }
 }
 
 // ---------- 2) Router -------------------------------------------------------


### PR DESCRIPTION
## Summary
- Defer Razathaar quest button interactions before role assignment
- Update Razathaar quest menu to edit deferred replies
- Log and surface errors during quest startup and menu display

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897be250cac832eb16453f866b1e9e8