### PR TITLE
Add ships category to data wiki

### DIFF
--- a/modules/data/ships.js
+++ b/modules/data/ships.js
@@ -1,0 +1,10 @@
+const { EmbedBuilder } = require('discord.js');
+
+module.exports = async (interaction) => {
+  const embed = new EmbedBuilder()
+    .setTitle('STARSHIP REGISTRY')
+    .setDescription('Technical readouts for notable ships.')
+    .setColor(0x0ea5e9);
+
+  await interaction.reply({ embeds: [embed], ephemeral: true });
+};

--- a/modules/data/wiki.json
+++ b/modules/data/wiki.json
@@ -72,6 +72,18 @@
       "image": "https://i.imgur.com/7jj3HO0.png"
     }
   ],
+  "ships": [
+    {
+      "title": "Mordecai-class Patrol Cutter",
+      "content": "Federation frontier outposts rely on Mordecai-class cutters for rapid response and interdiction. Durable and over-engined, these ships chase smugglers through debris fields and escort convoys across unsecured lanes.",
+      "image": "https://i.imgur.com/ship1.png"
+    },
+    {
+      "title": "Razorwind Interceptor",
+      "content": "A blade-winged interceptor favored by Dominion raiding wings. Its plasma-lanced engines burn hot enough to score its own hull, trading longevity for terrifying burst speed.",
+      "image": "https://i.imgur.com/ship2.png"
+    }
+  ],
   "planets": [
     {
       "title": "Calisa VII",


### PR DESCRIPTION
## Summary
- add `ships` dataset for starship entries
- include handler to render ship embed

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897c36bbd40832ea215f307df756986