### PR TITLE
feat: update Dyne Rift map image

### DIFF
--- a/commands/map.js
+++ b/commands/map.js
@@ -14,6 +14,7 @@ module.exports = {
 
   async execute(interaction) {
     const mapUrl = 'https://i.imgur.com/wbC8ZI8.jpeg';
+    const DYNE_RIFT_IMAGE_URL = 'https://i.imgur.com/O7I3Gnz.jpeg';
 
     const buildMainRow = () =>
       new ActionRowBuilder().addComponents(
@@ -64,7 +65,7 @@ module.exports = {
       new EmbedBuilder()
         .setTitle('DYNE RIFT SECTOR')
         .setDescription('Select a sub-system.')
-        .setImage(mapUrl);
+        .setImage(DYNE_RIFT_IMAGE_URL);
 
     const showMain = async i => {
       await i.update({ embeds: [mainEmbed()], components: [buildMainRow()] });


### PR DESCRIPTION
## Summary
- add dedicated Dyne Rift image URL constant
- show new Dyne Rift image in Dyne sector overview

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4351c7b6c832e9c802145db40c8cf