### PR TITLE
Add sector navigation to map command

### DIFF
--- a/__tests__/map.test.js
+++ b/__tests__/map.test.js
@@ -1,0 +1,57 @@
+const mapCommand = require('../commands/map');
+const { EmbedBuilder } = require('discord.js');
+
+describe('map command', () => {
+  const setup = async () => {
+    const handlers = {};
+    const reply = jest.fn().mockResolvedValue({
+      createMessageComponentCollector: jest.fn(() => ({
+        on: (event, fn) => {
+          handlers[event] = fn;
+        }
+      })),
+      editable: true,
+      edit: jest.fn().mockResolvedValue()
+    });
+    const interaction = { reply, user: { id: '1' } };
+    await mapCommand.execute(interaction);
+    return { handlers, reply };
+  };
+
+  test('shows main menu with sectors and cosmos', async () => {
+    const { reply } = await setup();
+    const { embeds, components } = reply.mock.calls[0][0];
+    expect(embeds[0]).toBeInstanceOf(EmbedBuilder);
+    const ids = components[0].components.map(c => c.data.custom_id);
+    expect(ids).toEqual(['cat_sectors', 'cat_cosmos']);
+  });
+
+  test('sector and system flow for Nullwek', async () => {
+    const { handlers } = await setup();
+    const collect = handlers.collect;
+
+    const update = jest.fn().mockResolvedValue();
+
+    await collect({ customId: 'cat_sectors', update });
+    let args = update.mock.calls[0][0];
+    expect(args.components[0].components[0].data.custom_id).toBe('sector_select');
+
+    update.mockReset();
+    await collect({ customId: 'sector_select', values: ['nullwek'], update });
+    args = update.mock.calls[0][0];
+    expect(args.embeds[0].data.title).toBe('THE NULLWEK SECTOR');
+    expect(args.components[0].components[0].data.custom_id).toBe('nullwek_select');
+
+    update.mockReset();
+    await collect({ customId: 'nullwek_select', values: ['thalyron'], update });
+    args = update.mock.calls[0][0];
+    expect(args.embeds[0].data.title).toBe('Thalyron');
+    expect(args.components[0].components[0].data.custom_id).toBe('back_sector');
+
+    update.mockReset();
+    await collect({ customId: 'back_sector', update });
+    args = update.mock.calls[0][0];
+    expect(args.components[0].components[0].data.custom_id).toBe('sector_select');
+  });
+});
+

--- a/commands/map.js
+++ b/commands/map.js
@@ -15,21 +15,55 @@ module.exports = {
   async execute(interaction) {
     const mapUrl = 'https://i.imgur.com/wbC8ZI8.jpeg';
     const DYNE_RIFT_IMAGE_URL = 'https://i.imgur.com/O7I3Gnz.jpeg';
+    const NULLWEK_IMAGE_URL = 'https://i.imgur.com/tm7B9PU.jpeg';
+    const ASHEN_VERGE_IMAGE_URL = 'https://i.imgur.com/ijSkWYs.jpeg';
 
+    // Builders
     const buildMainRow = () =>
       new ActionRowBuilder().addComponents(
         new ButtonBuilder()
-          .setCustomId('cat_solara')
-          .setLabel('Solara-Ys')
-          .setStyle(ButtonStyle.Primary),
-        new ButtonBuilder()
-          .setCustomId('cat_dyne')
-          .setLabel('Dyne Rift Sector')
+          .setCustomId('cat_sectors')
+          .setLabel('Sectors')
           .setStyle(ButtonStyle.Primary),
         new ButtonBuilder()
           .setCustomId('cat_cosmos')
           .setLabel('Cosmos')
           .setStyle(ButtonStyle.Primary)
+      );
+
+    const buildSectorSelect = () =>
+      new ActionRowBuilder().addComponents(
+        new StringSelectMenuBuilder()
+          .setCustomId('sector_select')
+          .addOptions(
+            { label: 'The Nullwek Sector', value: 'nullwek' },
+            { label: 'Ashen Verge Sector', value: 'ashen' },
+            { label: 'Dyne Rift Sector', value: 'dyne' }
+          )
+      );
+
+    const buildNullwekSelect = () =>
+      new ActionRowBuilder().addComponents(
+        new StringSelectMenuBuilder()
+          .setCustomId('nullwek_select')
+          .addOptions(
+            { label: 'Thalyron', value: 'thalyron' },
+            { label: 'Icarra', value: 'icarra' },
+            { label: 'Drosven', value: 'drosven' },
+            { label: 'Pyralis', value: 'pyralis' }
+          )
+      );
+
+    const buildAshenSelect = () =>
+      new ActionRowBuilder().addComponents(
+        new StringSelectMenuBuilder()
+          .setCustomId('ashen_select')
+          .addOptions(
+            { label: 'Serothis', value: 'serothis' },
+            { label: 'Eryndor', value: 'eryndor' },
+            { label: 'Caluth', value: 'caluth' },
+            { label: 'Kaivorn', value: 'kaivorn' }
+          )
       );
 
     const buildDyneSelect = () =>
@@ -51,33 +85,74 @@ module.exports = {
         .setStyle(ButtonStyle.Secondary)
     );
 
-    const backDyneRow = new ActionRowBuilder().addComponents(
+    const backSectorsRow = new ActionRowBuilder().addComponents(
       new ButtonBuilder()
-        .setCustomId('back_dyne')
+        .setCustomId('back_sectors')
         .setLabel('← Back')
         .setStyle(ButtonStyle.Secondary)
     );
 
+    const backSectorRow = new ActionRowBuilder().addComponents(
+      new ButtonBuilder()
+        .setCustomId('back_sector')
+        .setLabel('← Back')
+        .setStyle(ButtonStyle.Secondary)
+    );
+
+    // Embeds
     const mainEmbed = () =>
       new EmbedBuilder().setTitle('NEXI GALACTIC MAP').setImage(mapUrl);
+
+    const sectorsEmbed = () =>
+      new EmbedBuilder()
+        .setTitle('SECTORS')
+        .setDescription('Select a sector.')
+        .setImage(mapUrl);
 
     const dyneEmbed = () =>
       new EmbedBuilder()
         .setTitle('DYNE RIFT SECTOR')
-        .setDescription('Select a sub-system.')
+        .setDescription('Select a system.')
         .setImage(DYNE_RIFT_IMAGE_URL);
 
+    const nullwekEmbed = () =>
+      new EmbedBuilder()
+        .setTitle('THE NULLWEK SECTOR')
+        .setDescription('Select a system.')
+        .setImage(NULLWEK_IMAGE_URL);
+
+    const ashenEmbed = () =>
+      new EmbedBuilder()
+        .setTitle('ASHEN VERGE SECTOR')
+        .setDescription('Select a system.')
+        .setImage(ASHEN_VERGE_IMAGE_URL);
+
+    // Helpers
     const showMain = async i => {
       await i.update({ embeds: [mainEmbed()], components: [buildMainRow()] });
     };
 
-    const showDyne = async i => {
+    const showSectors = async i => {
       await i.update({
-        embeds: [dyneEmbed()],
-        components: [buildDyneSelect(), backMainRow]
+        embeds: [sectorsEmbed()],
+        components: [buildSectorSelect(), backMainRow]
       });
     };
 
+    const showSector = async (i, sector) => {
+      const builders = {
+        nullwek: [nullwekEmbed, buildNullwekSelect],
+        ashen: [ashenEmbed, buildAshenSelect],
+        dyne: [dyneEmbed, buildDyneSelect]
+      };
+      const [embedFn, selectFn] = builders[sector];
+      await i.update({
+        embeds: [embedFn()],
+        components: [selectFn(), backSectorsRow]
+      });
+    };
+
+    // Init
     const msg = await interaction.reply({
       embeds: [mainEmbed()],
       components: [buildMainRow()],
@@ -90,58 +165,105 @@ module.exports = {
       time: 3 * 60 * 1000
     });
 
+    // Handler
     collector.on('collect', async i => {
       const id = i.customId;
 
-      if (id === 'cat_dyne') {
-        await showDyne(i);
+      if (id === 'cat_sectors') {
+        await showSectors(i);
         return;
       }
 
-      if (id === 'cat_solara' || id === 'cat_cosmos') {
-        if (id === 'cat_solara') {
-          const embed = new EmbedBuilder()
-            .setTitle('Solara-Ys')
-            .setDescription(
-              'They call it the Lantern, Solara-Ys, burning steady in the Rift. Around it spin broken worlds: Keryn, scorched and silent; Dravona, red with rusted secrets; Ysoli Prime, where Aegir Station clings to orbit like a rusted crown; and beyond, the ice-laced Neyara.\nBetween them drifts the Graven Belt—miner-choked, pirate-haunted, rich with Oblivion Ore.'
-            )
-            .setImage('https://i.imgur.com/r5n96l0.jpeg');
-          await i.update({ embeds: [embed], components: [backMainRow] });
-        } else {
-          await i.update({
-            embeds: [new EmbedBuilder().setTitle('Cosmos').setImage(mapUrl)],
-            components: [backMainRow]
-          });
-        }
+      if (id === 'cat_cosmos') {
+        await i.update({
+          embeds: [new EmbedBuilder().setTitle('Cosmos').setImage(mapUrl)],
+          components: [backMainRow]
+        });
         return;
       }
 
-      if (id === 'dyne_select') {
+      if (id === 'sector_select') {
+        const sector = i.values[0];
+        await showSector(i, sector);
+        return;
+      }
+
+      if (id === 'nullwek_select' || id === 'ashen_select' || id === 'dyne_select') {
         const value = i.values[0];
-        const names = {
-          solara: 'Solara-Ys',
-          veyra: 'Veyra-Null System',
-          orphean: 'Orphean Verge',
-          aelyth: 'Aelyth Prime'
+
+        const data = {
+          nullwek_select: {
+            names: {
+              thalyron: 'Thalyron',
+              icarra: 'Icarra',
+              drosven: 'Drosven',
+              pyralis: 'Pyralis'
+            },
+            descriptions: {
+              thalyron: 'Thalyron shimmers with aurora-lit skies and silent ruins.',
+              icarra: 'Icarra rings with crystalline dust and forgotten towers.',
+              drosven: 'Drosven is a storm-swept world of rust deserts.',
+              pyralis: 'Pyralis burns with volcanic fury beneath ember clouds.'
+            },
+            images: {
+              thalyron: 'https://i.imgur.com/5xluzgp.jpeg',
+              icarra: 'https://i.imgur.com/k8G2M2e.jpeg',
+              drosven: 'https://i.imgur.com/ivJ1XNJ.jpeg',
+              pyralis: 'https://i.imgur.com/T6vmGyF.jpeg'
+            }
+          },
+          ashen_select: {
+            names: {
+              serothis: 'Serothis',
+              eryndor: 'Eryndor',
+              caluth: 'Caluth',
+              kaivorn: 'Kaivorn'
+            },
+            descriptions: {
+              serothis: 'Serothis drifts through grey nebulae and broken moons.',
+              eryndor: 'Eryndor glows with volcanic craters and haunted mines.',
+              caluth: 'Caluth is a dark water world of slow tides.',
+              kaivorn: "Kaivorn's shattered rings whisper of lost empires."
+            },
+            images: {
+              serothis: 'https://i.imgur.com/v3cEKuG.jpeg',
+              eryndor: 'https://i.imgur.com/hi7ZZo9.jpeg',
+              caluth: 'https://i.imgur.com/UrkKtaT.jpeg',
+              kaivorn: 'https://i.imgur.com/nueJkx0.jpeg'
+            }
+          },
+          dyne_select: {
+            names: {
+              solara: 'Solara-Ys',
+              veyra: 'Veyra-Null System',
+              orphean: 'Orphean Verge',
+              aelyth: 'Aelyth Prime'
+            },
+            descriptions: {
+              solara:
+                'They call it the Lantern, Solara-Ys, burning steady in the Rift. Around it spin broken worlds: Keryn, scorched and silent; Dravona, red with rusted secrets; Ysoli Prime, where Aegir Station clings to orbit like a rusted crown; and beyond, the ice-laced Neyara.\nBetween them drifts the Graven Belt—miner-choked, pirate-haunted, rich with Oblivion Ore.',
+              veyra:
+                'A null zone where collapsed stars whisper against the void.\nStation husks drift among gravity scars, their beacons flickering like fading memories.',
+              orphean:
+                'The Verge is a labyrinth of shattered hyperlanes and scavenger havens.\nEvery route is rumor; every signal might be salvage or snare.',
+              aelyth:
+                'Crystal horizons and psionic squalls define Aelyth Prime.\nPilgrims brave the storms to touch the echoing relics buried beneath its sands.'
+            },
+            images: {
+              solara: 'https://i.imgur.com/r5n96l0.jpeg',
+              veyra: 'https://i.imgur.com/Nzo4eZr.jpeg',
+              orphean: 'https://i.imgur.com/Y4gPYZK.jpeg',
+              aelyth: 'https://i.imgur.com/CXwznp1.jpeg'
+            }
+          }
         };
-        const descriptions = {
-          solara:
-            'They call it the Lantern, Solara-Ys, burning steady in the Rift. Around it spin broken worlds: Keryn, scorched and silent; Dravona, red with rusted secrets; Ysoli Prime, where Aegir Station clings to orbit like a rusted crown; and beyond, the ice-laced Neyara.\nBetween them drifts the Graven Belt—miner-choked, pirate-haunted, rich with Oblivion Ore.',
-          veyra: `A null zone where collapsed stars whisper against the void.\nStation husks drift among gravity scars, their beacons flickering like fading memories.`,
-          orphean: `The Verge is a labyrinth of shattered hyperlanes and scavenger havens.\nEvery route is rumor; every signal might be salvage or snare.`,
-          aelyth: `Crystal horizons and psionic squalls define Aelyth Prime.\nPilgrims brave the storms to touch the echoing relics buried beneath its sands.`
-        };
-        const images = {
-          solara: 'https://i.imgur.com/r5n96l0.jpeg',
-          veyra: 'https://i.imgur.com/Nzo4eZr.jpeg',
-          orphean: 'https://i.imgur.com/Y4gPYZK.jpeg',
-          aelyth: 'https://i.imgur.com/CXwznp1.jpeg'
-        };
+
+        const sectorData = data[id];
         const embed = new EmbedBuilder()
-          .setTitle(names[value])
-          .setDescription(descriptions[value])
-          .setImage(images[value]);
-        await i.update({ embeds: [embed], components: [backDyneRow] });
+          .setTitle(sectorData.names[value])
+          .setDescription(sectorData.descriptions[value])
+          .setImage(sectorData.images[value]);
+        await i.update({ embeds: [embed], components: [backSectorRow] });
         return;
       }
 
@@ -150,8 +272,8 @@ module.exports = {
         return;
       }
 
-      if (id === 'back_dyne') {
-        await showDyne(i);
+      if (id === 'back_sectors' || id === 'back_sector') {
+        await showSectors(i);
         return;
       }
     });


### PR DESCRIPTION
## Summary
- refactor map command with new sectors menu and per-sector system selectors
- add embeds and navigation buttons for Nullwek, Ashen, and Dyne sectors
- add tests covering sector and system flows

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bad6dea6f0832e86e23a75b099892e