### PR TITLE
fix: update Serothis image URL

### DIFF
--- a/commands/map.js
+++ b/commands/map.js
@@ -226,7 +226,7 @@ module.exports = {
               kaivorn: "Kaivorn's shattered rings whisper of lost empires."
             },
             images: {
-              serothis: 'https://i.imgur.com/v3cEKuG.jpeg',
+              serothis: 'https://i.imgur.com/AmjPsFb.jpeg',
               eryndor: 'https://i.imgur.com/hi7ZZo9.jpeg',
               caluth: 'https://i.imgur.com/UrkKtaT.jpeg',
               kaivorn: 'https://i.imgur.com/nueJkx0.jpeg'


### PR DESCRIPTION
## Summary
- fix Serothis image link in Ashen Verge selector

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bada4fa9a0832e990d7cd18b99acbc