### PR TITLE
feat: update Nullwek sector map image

### DIFF
--- a/__tests__/map.test.js
+++ b/__tests__/map.test.js
@@ -40,6 +40,7 @@ describe('map command', () => {
     await collect({ customId: 'sector_select', values: ['nullwek'], update });
     args = update.mock.calls[0][0];
     expect(args.embeds[0].data.title).toBe('THE NULLWEK SECTOR');
+    expect(args.embeds[0].data.image.url).toBe('https://i.imgur.com/OvKSoNl.jpeg');
     expect(args.components[0].components[0].data.custom_id).toBe('nullwek_select');
 
     update.mockReset();

--- a/commands/map.js
+++ b/commands/map.js
@@ -15,7 +15,7 @@ module.exports = {
   async execute(interaction) {
     const mapUrl = 'https://i.imgur.com/wbC8ZI8.jpeg';
     const DYNE_RIFT_IMAGE_URL = 'https://i.imgur.com/O7I3Gnz.jpeg';
-    const NULLWEK_IMAGE_URL = 'https://i.imgur.com/tm7B9PU.jpeg';
+    const NULLWEK_IMAGE_URL = 'https://i.imgur.com/OvKSoNl.jpeg';
     const ASHEN_VERGE_IMAGE_URL = 'https://i.imgur.com/ijSkWYs.jpeg';
 
     // Builders


### PR DESCRIPTION
## Summary
- update Nullwek sector map image URL
- assert new map image in Nullwek flow test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68badaffcd4c832ebd768eb4a25ab1ff