### PR TITLE
feat: expand news update interval

### DIFF
--- a/modules/news.js
+++ b/modules/news.js
@@ -1,8 +1,8 @@
 const { getNews } = require('./cache');
 
 function getRandomDelay() {
-  const min = 5 * 60 * 60 * 1000; // 5 hours
-  const max = 6 * 60 * 60 * 1000; // 6 hours
+  const min = 10 * 60 * 60 * 1000; // 10 hours
+  const max = 12 * 60 * 60 * 1000; // 12 hours
   return Math.floor(Math.random() * (max - min) + min);
 }
 


### PR DESCRIPTION
## Summary
- extend random delay for news cycle to 10-12 hours

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bd58a8f954832e817f59604198b244