### PR TITLE
Add mine session helpers to client manager

### DIFF
--- a/clientManager.js
+++ b/clientManager.js
@@ -1,0 +1,36 @@
+const raidSessions = new Map();
+
+function getRaidSession(userId) {
+  return raidSessions.get(userId);
+}
+
+function setRaidSession(userId, data) {
+  raidSessions.set(userId, data);
+}
+
+function clearRaidSession(userId) {
+  raidSessions.delete(userId);
+}
+
+const mineSessions = new Map();
+
+function getMineSession(userId) {
+  return mineSessions.get(userId);
+}
+
+function setMineSession(userId, data) {
+  mineSessions.set(userId, data);
+}
+
+function clearMineSession(userId) {
+  mineSessions.delete(userId);
+}
+
+module.exports = {
+  getRaidSession,
+  setRaidSession,
+  clearRaidSession,
+  getMineSession,
+  setMineSession,
+  clearMineSession
+};


### PR DESCRIPTION
## Summary
- add clientManager module with raid and mine session maps
- expose get/set/clear functions for mine sessions to prevent clashes with raid sessions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c14179a3c4832eaeb0ea454a9b0c33