### PR TITLE
Add Eagle Republic faction option to data command

### DIFF
--- a/commands/data.js
+++ b/commands/data.js
@@ -12,7 +12,8 @@ const joinableEmpires = {
   'The Trade Federation': 'trade',
   'Yamato Syndicate': 'yamato',
   'Nova Confederation': 'nova',
-  'Crimson Collective': 'crimson'
+  'Crimson Collective': 'crimson',
+  'Eagle Republic': 'eagle'
 };
 
 module.exports = {
@@ -147,7 +148,8 @@ module.exports = {
           trade: 'Trade Federation',
           yamato: 'Yamato Syndicate',
           nova: 'Nova Confederation',
-          crimson: 'Crimson Collective'
+          crimson: 'Crimson Collective',
+          eagle: 'Eagle Republic'
         };
 
         const factionKey = cat;

--- a/modules/data/wiki.json
+++ b/modules/data/wiki.json
@@ -90,6 +90,11 @@
     "title": "Crimson Collective",
     "content": "After a major global conflict, the Crimson Collective found itself at odds with its ideological enemies who consolidated the other portion of the planet, resulting in a continuation war which brought deep patriotism and close ties between the Socialist factions. Their capitalist counterparts instead faced division and conflict of interests, being conquered over the span of the next few hundred years.",
     "image": "https://i.imgur.com/wNCm2SH.png"
+  },
+  {
+    "title": "Eagle Republic",
+    "content": "A Republic built from the civil war that plagued its Homeworld. A place ravaged by death, war and Traitors. With the loyalist at there last line of defense against the Demons that attacked them. All that was left was…… self annihilation. With a press of a button the planet that was once vibrant with colors and animals now had a Black and green hue that consumed the planet whole. The loyalist failed to win the war without the use of these weapons. The leader Ajax before he was killed evacuating those to the last line of defense gave an order to not use these weapons that there was another way. Now the people of these land swear an oath to atone for what they have done to the planet and against the will of their leader. For they have nothing but there lives to give as There duty is to serve his will. With his bloodline still alive, there is still hope for Them.",
+    "image": "https://i.imgur.com/wNCm2SH.png"
   }
 ],
   "planets": [


### PR DESCRIPTION
## Summary
- allow the Eagle Republic entry in the /data empires category to expose a Join button and grant its role
- document the Eagle Republic lore inside the empires section of the data library

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d3aa595768832eb0947f9e9094f72a