### PR TITLE
Update Ormun system map details

### DIFF
--- a/commands/map.js
+++ b/commands/map.js
@@ -350,12 +350,13 @@ module.exports = {
             },
             descriptions: {
               drelith: 'Drelith bristles with Crimson battlements and shipyards.',
-              ormun: 'Ormun is a fortified frontier world patrolled by warfleets.',
+              ormun:
+                'Ormun System — the Crimson Collective domain, with their homeworld Crimson Prime.',
               vayth: 'Vayth glows with munitions foundries beneath scarlet skies.'
             },
             images: {
               drelith: 'https://i.imgur.com/fkjNogD.png',
-              ormun: 'https://i.imgur.com/fkjNogD.png',
+              ormun: 'https://i.imgur.com/IXATqGb.jpeg',
               vayth: 'https://i.imgur.com/fkjNogD.png'
             }
           },


### PR DESCRIPTION
## Summary
- update the Ormun system description to highlight the Crimson Collective and Crimson Prime
- set the Ormun system map image to the new provided artwork

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d40edd7e30832e8e16cab9f27d2c15