### PR TITLE
Add Neurolate ambassador ad entry and button handling

### DIFF
--- a/ads.json
+++ b/ads.json
@@ -83,14 +83,21 @@
   "image": "https://i.imgur.com/cMnHiUs.png",
   "sponsor": "HYPERTRIP"
   },
-{
-  "type": "ad",
-  "title": "CALLING ALL LIGHT-FREIGHT CAPTAINS",
-  "text": "Kawazei Systems seeks one gargo-rated hauler to uplift 6t sealed cargo from Razathaar to Aegir Orbit.",
-  "image": "https://i.imgur.com/d6Q4rlf.png",
-  "sponsor": "Kawazei Systems"
+  {
+    "type": "ad",
+    "title": "CALLING ALL LIGHT-FREIGHT CAPTAINS",
+    "text": "Kawazei Systems seeks one gargo-rated hauler to uplift 6t sealed cargo from Razathaar to Aegir Orbit.",
+    "image": "https://i.imgur.com/d6Q4rlf.png",
+    "sponsor": "Kawazei Systems"
   },
- {
+  {
+    "type": "ad",
+    "title": "NEUROLATE AMBASSADOR PROGRAM",
+    "text": "Submit to evaluation. Represent the Trust across the frontier.",
+    "image": "https://i.imgur.com/y4LmNsi.png",
+    "sponsor": "NEUROLATE™ Biomedical Trust"
+  },
+  {
     "type": "ad",
     "title": "KALDUR PRIME",
     "text": "The final hunt.",

--- a/modules/ads.js
+++ b/modules/ads.js
@@ -35,18 +35,33 @@ async function postAd(client) {
   const isCalisa = title.includes("calisa");
   const isKaldur = title.includes("kaldur"); // match "kaldur prime" as well
   const isRazathaar = title.includes("light-freight");
+  const isNeurolate = title.includes("neurolate");
   let components = [];
-  if (isCalisa || isKaldur || isRazathaar) {
-    const button = new ButtonBuilder()
-      .setCustomId(
-        isCalisa
-          ? "calisa_buy_ticket"
-          : isKaldur
-          ? "kaldur_buy_ticket"
-          : "razathaar_start_quest"
-      )
-      .setLabel(isRazathaar ? "📦 Accept Contract" : "🎫 Buy Ticket")
+
+  let button = null;
+  if (isCalisa) {
+    button = new ButtonBuilder()
+      .setCustomId("calisa_buy_ticket")
+      .setLabel("🎫 Buy Ticket")
       .setStyle(ButtonStyle.Primary);
+  } else if (isKaldur) {
+    button = new ButtonBuilder()
+      .setCustomId("kaldur_buy_ticket")
+      .setLabel("🎫 Buy Ticket")
+      .setStyle(ButtonStyle.Primary);
+  } else if (isRazathaar) {
+    button = new ButtonBuilder()
+      .setCustomId("razathaar_start_quest")
+      .setLabel("📦 Accept Contract")
+      .setStyle(ButtonStyle.Primary);
+  } else if (isNeurolate) {
+    button = new ButtonBuilder()
+      .setCustomId("neurolate_start_exam")
+      .setLabel("APPLY NOW")
+      .setStyle(ButtonStyle.Primary);
+  }
+
+  if (button) {
     components = [new ActionRowBuilder().addComponents(button)];
   }
 


### PR DESCRIPTION
## Summary
- add the Neurolate Ambassador promo to the ad rotation with its assets
- extend ad button logic to support the Neurolate exam CTA while keeping mutually exclusive buttons

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6d4f3d11c832ebbd4304d293d4a87