### PR TITLE
Add Neurolate ambassador examination advertisement

### DIFF
--- a/ads.json
+++ b/ads.json
@@ -103,5 +103,12 @@
     "text": "The final hunt.",
     "image": "https://i.imgur.com/WdZImBi.png",
     "sponsor": "Hypertrip"
+  },
+  {
+    "type": "ad",
+    "title": "NEUROLATE™ AMBASSADOR EXAMINATION",
+    "text": "Undergo the Trust's full-spectrum evaluation. Secure ambassador clearance across the frontier.",
+    "image": "https://i.imgur.com/dIVmcw7.png",
+    "sponsor": "NEUROLATE™ Biomedical Trust"
   }
 ]


### PR DESCRIPTION
## Summary
- append a Neurolate ambassador examination listing to the ads data feed

## Testing
- not run (data-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d6dd106f2c832e949dbaa29bf98d14