### PR TITLE
Broaden Neurolate ad button detection

### DIFF
--- a/modules/ads.js
+++ b/modules/ads.js
@@ -35,7 +35,8 @@ async function postAd(client) {
   const isCalisa = title.includes("calisa");
   const isKaldur = title.includes("kaldur"); // match "kaldur prime" as well
   const isRazathaar = title.includes("light-freight");
-  const isNeurolate = title.includes("neurolate");
+  const isNeurolate =
+    title.includes("neurolate") || title.includes("ambassador examination");
   let components = [];
 
   let button = null;


### PR DESCRIPTION
## Summary
- expand the Neurolate ad detection to also cover Ambassador Examination ads so the CTA button appears consistently

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6ddcb5150832eb32df5162c51041d