### PR TITLE
Ensure Neurolate exam buttons encode answer index

### DIFF
--- a/modules/neurolateExam.js
+++ b/modules/neurolateExam.js
@@ -121,10 +121,10 @@ function buildQuestionRow(index, hasFailed) {
   const nextStep = index === QUESTIONS.length - 1 ? 'neurolate_complete' : `neurolate_q${index + 2}`;
   const row = new ActionRowBuilder();
 
-  const buttons = QUESTIONS[index].choices.map(choice => {
+  const buttons = QUESTIONS[index].choices.map((choice, i) => {
     const willFail = hasFailed || !choice.isCorrect;
     return new ButtonBuilder()
-      .setCustomId(`${nextStep}|${willFail ? 'fail' : 'ok'}`)
+      .setCustomId(`${nextStep}|${willFail ? 'fail' : 'ok'}|${i}`)
       .setLabel(choice.label)
       .setStyle(choice.isCorrect ? ButtonStyle.Success : ButtonStyle.Secondary);
   });
@@ -181,7 +181,7 @@ async function startNeurolateExam(interaction) {
 }
 
 async function handleNeurolateInteraction(interaction) {
-  const [base, statusToken] = interaction.customId.split('|');
+  const [base, statusToken] = interaction.customId.split('|', 3);
   const hasFailed = statusToken === 'fail';
 
   if (base === 'neurolate_complete') {


### PR DESCRIPTION
## Summary
- append the answer index to each Neurolate exam button custom ID to ensure uniqueness
- update the interaction handler to ignore the appended index while processing responses

## Testing
- node - <<'NODE'
const fs = require('fs');
const vm = require('vm');
const code = fs.readFileSync('./modules/neurolateExam.js', 'utf8');
const sandbox = { module: { exports: {} }, exports: {}, require, console, process };
vm.runInNewContext(code, sandbox);
const row = sandbox.buildQuestionRow(0, false);
const ids = row.components.map(button => button.data.custom_id);
console.log(ids);
console.log('Unique IDs:', new Set(ids).size === ids.length);
NODE

------
https://chatgpt.com/codex/tasks/task_e_68d6e5a5a788832eb6d3a26fefb3edb8