### PR TITLE
Use configured drug emoji in Neurolate exam messaging

### DIFF
--- a/__tests__/neurolateExam.test.js
+++ b/__tests__/neurolateExam.test.js
@@ -1,13 +1,36 @@
 const { ActionRowBuilder } = require('discord.js');
-const { startNeurolateExam, handleNeurolateInteraction } = require('../modules/neurolateExam');
+
+let startNeurolateExam;
+let handleNeurolateInteraction;
+
+function loadNeurolateModule() {
+  jest.resetModules();
+  ({ startNeurolateExam, handleNeurolateInteraction } = require('../modules/neurolateExam'));
+}
+
+const ORIGINAL_DRUG_EMOJI = process.env.DRUG_EMOJI_TAG;
+const ORIGINAL_NEWS_CHANNEL_NAME = process.env.NEWS_CHANNEL_NAME;
 
 describe('Neurolate exam flow', () => {
   beforeEach(() => {
+    loadNeurolateModule();
     jest.spyOn(console, 'warn').mockImplementation(() => {});
     jest.spyOn(console, 'error').mockImplementation(() => {});
   });
 
   afterEach(() => {
+    if (ORIGINAL_DRUG_EMOJI === undefined) {
+      delete process.env.DRUG_EMOJI_TAG;
+    } else {
+      process.env.DRUG_EMOJI_TAG = ORIGINAL_DRUG_EMOJI;
+    }
+
+    if (ORIGINAL_NEWS_CHANNEL_NAME === undefined) {
+      delete process.env.NEWS_CHANNEL_NAME;
+    } else {
+      process.env.NEWS_CHANNEL_NAME = ORIGINAL_NEWS_CHANNEL_NAME;
+    }
+
     jest.restoreAllMocks();
   });
 
@@ -27,6 +50,7 @@ describe('Neurolate exam flow', () => {
   }
 
   test('startNeurolateExam renders a select menu for choices', async () => {
+    loadNeurolateModule();
     const interaction = {
       deferred: false,
       replied: false,
@@ -49,7 +73,7 @@ describe('Neurolate exam flow', () => {
     expect(payload.components).toHaveLength(1);
 
     const row = payload.components[0];
-    expect(row).toBeInstanceOf(ActionRowBuilder);
+    expect(row?.constructor?.name).toBe(ActionRowBuilder.name);
 
     const rowJson = row.toJSON();
     expect(rowJson.components).toHaveLength(1);
@@ -59,7 +83,50 @@ describe('Neurolate exam flow', () => {
     expect(select.options[0].value).toContain('neurolate_q2');
   });
 
+  test('startNeurolateExam announces with configured drug emoji', async () => {
+    process.env.DRUG_EMOJI_TAG = '<:Drug:12345>';
+    process.env.NEWS_CHANNEL_NAME = 'station-news';
+
+    loadNeurolateModule();
+
+    const send = jest.fn().mockResolvedValue();
+    const newsChannel = {
+      name: 'station-news',
+      isTextBased: () => true,
+      send,
+    };
+
+    const guild = {
+      channels: {
+        cache: {
+          find: jest.fn(callback => (callback(newsChannel) ? newsChannel : undefined)),
+        },
+      },
+      roles: { cache: { find: jest.fn(() => undefined) } },
+    };
+
+    const interaction = {
+      deferred: false,
+      replied: false,
+      member: { roles: { cache: [] } },
+      guild,
+      deferReply: jest.fn().mockImplementation(function () {
+        interaction.deferred = true;
+        return Promise.resolve();
+      }),
+      editReply: jest.fn().mockResolvedValue(),
+    };
+
+    await startNeurolateExam(interaction);
+
+    expect(send).toHaveBeenCalled();
+    const [message] = send.mock.calls[0];
+    expect(typeof message).toBe('string');
+    expect(message.startsWith(process.env.DRUG_EMOJI_TAG)).toBe(true);
+  });
+
   test('handleNeurolateInteraction advances to next question via select value', async () => {
+    loadNeurolateModule();
     const interaction = {
       values: ['neurolate_q2|ok'],
       customId: 'neurolate_q1',
@@ -89,12 +156,96 @@ describe('Neurolate exam flow', () => {
     expect(nextPayload.components).toHaveLength(1);
 
     const row = nextPayload.components[0];
-    expect(row).toBeInstanceOf(ActionRowBuilder);
+    expect(row?.constructor?.name).toBe(ActionRowBuilder.name);
     const rowJson = row.toJSON();
     expect(rowJson.components[0].custom_id).toBe('neurolate_q2');
   });
 
+  test('handleNeurolateInteraction reports results with configured emoji', async () => {
+    process.env.DRUG_EMOJI_TAG = '<:Drug:12345>';
+    process.env.NEWS_CHANNEL_NAME = 'station-news';
+
+    loadNeurolateModule();
+
+    const send = jest.fn().mockResolvedValue();
+    const newsChannel = {
+      name: 'station-news',
+      isTextBased: () => true,
+      send,
+    };
+
+    const neurolateRole = { id: 'role-1', name: 'NEUROLATE' };
+    const ambassadorRole = { id: 'role-2', name: 'NEUROLATE AMBASSADOR' };
+    const assignedRoles = new Set([neurolateRole.id]);
+
+    const guild = {
+      channels: {
+        cache: {
+          find: jest.fn(callback => (callback(newsChannel) ? newsChannel : undefined)),
+        },
+      },
+      roles: {
+        cache: {
+          find: jest.fn(callback => {
+            if (callback(neurolateRole)) return neurolateRole;
+            if (callback(ambassadorRole)) return ambassadorRole;
+            return undefined;
+          }),
+        },
+      },
+    };
+
+    const member = {
+      roles: {
+        cache: {
+          has: jest.fn(id => assignedRoles.has(id)),
+        },
+        remove: jest.fn(role => {
+          assignedRoles.delete(role.id);
+          return Promise.resolve();
+        }),
+        add: jest.fn(role => {
+          assignedRoles.add(role.id);
+          return Promise.resolve();
+        }),
+      },
+    };
+
+    const interaction = {
+      values: ['neurolate_complete|ok'],
+      customId: 'neurolate_q10',
+      message: {
+        components: [
+          {
+            components: [
+              {
+                customId: 'neurolate_q10',
+                options: [{ value: 'neurolate_complete|ok' }],
+              },
+            ],
+          },
+        ],
+      },
+      update: jest.fn().mockResolvedValue(),
+      followUp: jest.fn().mockResolvedValue(),
+      guild,
+      member,
+    };
+
+    await handleNeurolateInteraction(interaction);
+
+    expect(interaction.followUp).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringMatching(new RegExp(`^${process.env.DRUG_EMOJI_TAG}`)),
+      })
+    );
+    expect(send).toHaveBeenCalled();
+    const [announcement] = send.mock.calls[0];
+    expect(announcement.startsWith(process.env.DRUG_EMOJI_TAG)).toBe(true);
+  });
+
   test('stale submissions are ignored with deferUpdate', async () => {
+    loadNeurolateModule();
     const interaction = {
       values: ['neurolate_q2|ok'],
       customId: 'neurolate_q1',

--- a/modules/neurolateExam.js
+++ b/modules/neurolateExam.js
@@ -8,19 +8,20 @@ const {
 } = require('discord.js');
 
 const POSTER_IMAGE = 'https://i.imgur.com/KTYU4Jj.png';
+const DRUG_EMOJI = process.env.DRUG_EMOJI_TAG ?? '💊';
 
 const SUBMISSION_BLURBS = [
-  '💊 PRIORITY UPDATE: Neurolate docket pinged by MedOps. Candidate entering cognition cradle under observation.',
-  '💊 SIGNAL: Neurolate intake corridor sealed. Exam recorders spinning up for fresh certification attempt.',
-  '💊 OPERATIONS NOTE: Neurolate proctor flagged new submission. Mentors requested to monitor drift metrics in real time.',
-  '💊 CHANNEL 6: Neurolate cadet strapped in. Archive relay streaming every response for post-run audit.',
+  `${DRUG_EMOJI} PRIORITY UPDATE: Neurolate docket pinged by MedOps. Candidate entering cognition cradle under observation.`,
+  `${DRUG_EMOJI} SIGNAL: Neurolate intake corridor sealed. Exam recorders spinning up for fresh certification attempt.`,
+  `${DRUG_EMOJI} OPERATIONS NOTE: Neurolate proctor flagged new submission. Mentors requested to monitor drift metrics in real time.`,
+  `${DRUG_EMOJI} CHANNEL 6: Neurolate cadet strapped in. Archive relay streaming every response for post-run audit.`,
 ];
 
 const SUCCESS_BLURBS = [
-  '💊 PRIORITY BROADCAST: Neurolate Ambassador cleared with zero faults. Station protocol uplinks refreshed immediately.',
-  '💊 COMMAND WIRE: Neurolate exam returned flawless. Ambassador insignia granted and medbay cheers logged.',
-  '💊 ARCHIVE ENTRY: Neurolate candidate recorded a perfect series. Ambassador network expanding before next drift cycle.',
-  '💊 STATUS GREEN: Neurolate run completed without deviation. Ambassador credentials synced across all rosters.',
+  `${DRUG_EMOJI} PRIORITY BROADCAST: Neurolate Ambassador cleared with zero faults. Station protocol uplinks refreshed immediately.`,
+  `${DRUG_EMOJI} COMMAND WIRE: Neurolate exam returned flawless. Ambassador insignia granted and medbay cheers logged.`,
+  `${DRUG_EMOJI} ARCHIVE ENTRY: Neurolate candidate recorded a perfect series. Ambassador network expanding before next drift cycle.`,
+  `${DRUG_EMOJI} STATUS GREEN: Neurolate run completed without deviation. Ambassador credentials synced across all rosters.`,
 ];
 
 const QUESTIONS = [
@@ -146,7 +147,7 @@ async function startNeurolateExam(interaction) {
 
     if (alreadyCertified) {
       const alreadyMessage = {
-        content: '💊 You have already attempted the Neurolate exam.',
+        content: `${DRUG_EMOJI} You have already attempted the Neurolate exam.`,
       };
 
       if (interaction.deferred || interaction.replied) {
@@ -216,8 +217,8 @@ async function handleNeurolateInteraction(interaction) {
 
     const perfectRun = !hasFailed;
     const followUp = perfectRun
-      ? '💊 Results: flawless execution. Neurolate Ambassador status confirmed — stand by for role sync.'
-      : '💊 Results: at least one response failed review. Neurolate certification (standard) recorded.';
+      ? `${DRUG_EMOJI} Results: flawless execution. Neurolate Ambassador status confirmed — stand by for role sync.`
+      : `${DRUG_EMOJI} Results: at least one response failed review. Neurolate certification (standard) recorded.`;
 
     await interaction.followUp({ content: followUp, flags: MessageFlags.Ephemeral });
 


### PR DESCRIPTION
## Summary
- add a configurable Neurolate drug emoji constant and apply it across announcement and result messages
- ensure Neurolate exam tests load the updated module per configuration and verify emoji usage in notifications

## Testing
- npm test -- neurolateExam

------
https://chatgpt.com/codex/tasks/task_e_68d6ef58e3bc832eba449250685368e4