### PR TITLE
Ensure neurolate exam failures jump to completion

### DIFF
--- a/modules/neurolateExam.js
+++ b/modules/neurolateExam.js
@@ -119,7 +119,7 @@ function buildQuestionEmbed(index) {
 }
 
 function buildQuestionRow(index, hasFailed) {
-  const nextStep = index === QUESTIONS.length - 1 ? 'neurolate_complete' : `neurolate_q${index + 2}`;
+  const nextSuccessStep = index === QUESTIONS.length - 1 ? 'neurolate_complete' : `neurolate_q${index + 2}`;
   const select = new StringSelectMenuBuilder()
     .setCustomId(`neurolate_q${index + 1}`)
     .setPlaceholder('Select your answer')
@@ -128,9 +128,10 @@ function buildQuestionRow(index, hasFailed) {
     .addOptions(
       QUESTIONS[index].choices.map(choice => {
         const willFail = hasFailed || !choice.isCorrect;
+        const targetStep = willFail ? 'neurolate_complete' : nextSuccessStep;
         return {
           label: choice.label,
-          value: `${nextStep}|${willFail ? 'fail' : 'ok'}`,
+          value: `${targetStep}|${willFail ? 'fail' : 'ok'}`,
         };
       })
     );


### PR DESCRIPTION
## Summary
- compute the next success step for neurolate exam prompts
- direct failed or previously failed answers to the completion step while keeping failure tokens

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6f7be2f7c832eb606ef3790b17610