### PR TITLE
Ensure neurolate exam choices encode index

### DIFF
--- a/modules/neurolateExam.js
+++ b/modules/neurolateExam.js
@@ -126,12 +126,12 @@ function buildQuestionRow(index, hasFailed) {
     .setMinValues(1)
     .setMaxValues(1)
     .addOptions(
-      QUESTIONS[index].choices.map(choice => {
+      QUESTIONS[index].choices.map((choice, choiceIndex) => {
         const willFail = hasFailed || !choice.isCorrect;
         const targetStep = willFail ? 'neurolate_complete' : nextSuccessStep;
         return {
           label: choice.label,
-          value: `${targetStep}|${willFail ? 'fail' : 'ok'}`,
+          value: `${targetStep}|${willFail ? 'fail' : 'ok'}|${choiceIndex}`,
         };
       })
     );


### PR DESCRIPTION
## Summary
- append the choice index to neurolate exam select values to ensure each option is unique while retaining flow metadata

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6f8920164832e95e47f390aa956ca