### PR TITLE
Update Neurolate exam default emoji

### DIFF
--- a/modules/neurolateExam.js
+++ b/modules/neurolateExam.js
@@ -8,7 +8,7 @@ const {
 } = require('discord.js');
 
 const POSTER_IMAGE = 'https://i.imgur.com/KTYU4Jj.png';
-const DRUG_EMOJI = process.env.DRUG_EMOJI_TAG ?? '💊';
+const DRUG_EMOJI = process.env.DRUG_EMOJI_TAG ?? '🧠';
 
 const SUBMISSION_BLURBS = [
   `${DRUG_EMOJI} PRIORITY UPDATE: Neurolate docket pinged by MedOps. Candidate entering cognition cradle under observation.`,


### PR DESCRIPTION
## Summary
- update the Neurolate exam module to default to the brain emoji when no override is provided

## Testing
- npm test -- neurolateExam

------
https://chatgpt.com/codex/tasks/task_e_68d71ca29f10832ea27bbf81f585033f