### PR TITLE
Configure Neurodrug emoji for Neurolate exam

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,15 @@ node deploy-commands.js
 node index.js
 ```
 
+### Configuration
+
+Set the following environment variables before launching the bot:
+
+| Variable | Description |
+| --- | --- |
+| `NEWS_CHANNEL_NAME` | Name of the channel used for news dispatches and Neurolate announcements. |
+| `NEURODRUG_EMOJI_TAG` | Custom emoji tag (e.g. `<:Neurodrug:12345>`) that prefixes all Neurolate exam blurbs and results. |
+
 ## `/review` Command
 
 Use `/review` in the channel defined by `NEWS_CHANNEL_NAME` to post a review embed. The modal includes an optional field labeled **"Message Link or ID (this server, optional)"**.

--- a/__tests__/neurolateExam.test.js
+++ b/__tests__/neurolateExam.test.js
@@ -8,6 +8,7 @@ function loadNeurolateModule() {
   ({ startNeurolateExam, handleNeurolateInteraction } = require('../modules/neurolateExam'));
 }
 
+const ORIGINAL_NEURODRUG_EMOJI = process.env.NEURODRUG_EMOJI_TAG;
 const ORIGINAL_DRUG_EMOJI = process.env.DRUG_EMOJI_TAG;
 const ORIGINAL_NEWS_CHANNEL_NAME = process.env.NEWS_CHANNEL_NAME;
 
@@ -19,6 +20,12 @@ describe('Neurolate exam flow', () => {
   });
 
   afterEach(() => {
+    if (ORIGINAL_NEURODRUG_EMOJI === undefined) {
+      delete process.env.NEURODRUG_EMOJI_TAG;
+    } else {
+      process.env.NEURODRUG_EMOJI_TAG = ORIGINAL_NEURODRUG_EMOJI;
+    }
+
     if (ORIGINAL_DRUG_EMOJI === undefined) {
       delete process.env.DRUG_EMOJI_TAG;
     } else {
@@ -84,7 +91,7 @@ describe('Neurolate exam flow', () => {
   });
 
   test('startNeurolateExam announces with configured drug emoji', async () => {
-    process.env.DRUG_EMOJI_TAG = '<:Drug:12345>';
+    process.env.NEURODRUG_EMOJI_TAG = '<:Drug:12345>';
     process.env.NEWS_CHANNEL_NAME = 'station-news';
 
     loadNeurolateModule();
@@ -122,7 +129,7 @@ describe('Neurolate exam flow', () => {
     expect(send).toHaveBeenCalled();
     const [message] = send.mock.calls[0];
     expect(typeof message).toBe('string');
-    expect(message.startsWith(process.env.DRUG_EMOJI_TAG)).toBe(true);
+    expect(message.startsWith(process.env.NEURODRUG_EMOJI_TAG)).toBe(true);
   });
 
   test('handleNeurolateInteraction advances to next question via select value', async () => {
@@ -162,7 +169,7 @@ describe('Neurolate exam flow', () => {
   });
 
   test('handleNeurolateInteraction reports results with configured emoji', async () => {
-    process.env.DRUG_EMOJI_TAG = '<:Drug:12345>';
+    process.env.NEURODRUG_EMOJI_TAG = '<:Drug:12345>';
     process.env.NEWS_CHANNEL_NAME = 'station-news';
 
     loadNeurolateModule();
@@ -236,12 +243,12 @@ describe('Neurolate exam flow', () => {
 
     expect(interaction.followUp).toHaveBeenCalledWith(
       expect.objectContaining({
-        content: expect.stringMatching(new RegExp(`^${process.env.DRUG_EMOJI_TAG}`)),
+        content: expect.stringMatching(new RegExp(`^${process.env.NEURODRUG_EMOJI_TAG}`)),
       })
     );
     expect(send).toHaveBeenCalled();
     const [announcement] = send.mock.calls[0];
-    expect(announcement.startsWith(process.env.DRUG_EMOJI_TAG)).toBe(true);
+    expect(announcement.startsWith(process.env.NEURODRUG_EMOJI_TAG)).toBe(true);
   });
 
   test('stale submissions are ignored with deferUpdate', async () => {

--- a/modules/neurolateExam.js
+++ b/modules/neurolateExam.js
@@ -8,7 +8,8 @@ const {
 } = require('discord.js');
 
 const POSTER_IMAGE = 'https://i.imgur.com/KTYU4Jj.png';
-const DRUG_EMOJI = process.env.DRUG_EMOJI_TAG ?? '🧠';
+const DRUG_EMOJI =
+  process.env.NEURODRUG_EMOJI_TAG ?? process.env.DRUG_EMOJI_TAG ?? '🧠';
 
 const SUBMISSION_BLURBS = [
   `${DRUG_EMOJI} PRIORITY UPDATE: Neurolate docket pinged by MedOps. Candidate entering cognition cradle under observation.`,


### PR DESCRIPTION
## Summary
- prefer the NEURODRUG_EMOJI_TAG environment variable so Neurolate blurbs and results use the custom emoji
- update the Neurolate exam tests to reflect the Neurodrug emoji configuration
- document the new environment variable in the setup instructions for operators

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d7258bf274832e807eaf10ce52ca49