### PR TITLE
Allow specific member to bypass account age gate

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,6 +22,11 @@ const client = new Client({
 });
 
 client.on('guildMemberAdd', async (member) => {
+    // Allow a specific user to bypass the new-account gate
+    if (member.id === '1425238632624689164') {
+        return; // do not kick or DM this user
+    }
+
     const accountAge = Date.now() - member.user.createdTimestamp;
     if (accountAge < 10 * 24 * 60 * 60 * 1000) {
         const explanationMessage = `Hey there! Thanks for joining **${member.guild.name}**. ` +


### PR DESCRIPTION
## Summary
- add an early return in the guildMemberAdd listener to exempt the specified user ID from the 10-day account age requirement

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e64cf94468832ea4d94a70a33ce74b